### PR TITLE
Backport "Support arm64 on OSX" (ostis-dev/sc-machine)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,24 @@ cmake_minimum_required (VERSION 2.8)
 
 set(SC_BIN_PATH "${CMAKE_CURRENT_LIST_DIR}/bin")
 
-set(SC_MACHINE_ROOT ${CMAKE_CURRENT_LIST_DIR})
-set(SC_MACHINE_THIRDPARTY_PATH "${SC_MACHINE_ROOT}/thirdparty")
+set (SC_MACHINE_ROOT ${CMAKE_CURRENT_LIST_DIR})
+set (SC_MACHINE_THIRDPARTY_PATH "${SC_MACHINE_ROOT}/thirdparty")
 
 option (SC_AUTO_TEST "Flag to build for automation testing" OFF)
 option (SC_KPM_SCP "Flag to build SCP module" OFF)
 option (SC_BUILD_SCTP "Flag to turn on/off sctp protocol support" ON)
 # Flag to build unit tests. Option is replaced with set because of option unpredictable behavior
 set(SC_BUILD_TESTS OFF)
+
+if (${SC_BUILD_ARM64})
+    check_c_compiler_flag("-arch arm64" IS_ARM64_SUPPORTED)
+    if (${IS_ARM64_SUPPORTED})
+        set (CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "Used architecture" FORCE)
+        message ("-- Architecture: arm64")
+    else()
+        message (FATAL_ERROR "Arm64 platform is not supported by compiler")
+    endif()
+endif()
 
 # codegen
 if (${UNIX})
@@ -78,8 +88,9 @@ if (${APPLE})
 
     set (GLIB2_LIBRARIES ${GLIB_LDFLAGS} ${GLIB2_MODULE_LDFLAGS})
 
-    set (LIBCLANG_LLVM_CONFIG_EXECUTABLE "/usr/local/opt/llvm/bin/llvm-config")
-    find_package(LibClang REQUIRED)
+    if (NOT DEFINED LIBCLANG_LIBRARIES OR NOT DEFINED LIBCLANG_CXXFLAGS OR NOT DEFINED LIBCLANG_LIBDIR)
+        find_package(LibClang REQUIRED)
+    endif ()
 
     find_package(PythonLibs 3.7 REQUIRED)
     find_package(curl REQUIRED)

--- a/cmake/FindLibClang.cmake
+++ b/cmake/FindLibClang.cmake
@@ -46,8 +46,16 @@ if (NOT LIBCLANG_LLVM_CONFIG_EXECUTABLE)
     set(LIBCLANG_LLVM_CONFIG_EXECUTABLE $ENV{LIBCLANG_LLVM_CONFIG_EXECUTABLE})
     if (NOT LIBCLANG_LLVM_CONFIG_EXECUTABLE)
         set(llvm_config_names llvm-config)
-        foreach(minor RANGE 9 1)
-            list(APPEND llvm_config_names "llvm-config-${minor}" "llvm-config-3.${minor}" "llvm-config-mp-3.${minor}")
+        foreach(minor RANGE 9 0)
+            list(APPEND llvm_config_names 
+                "llvm-config"
+                "llvm-config-7"
+                "llvm-config-6.${minor}"
+                "llvm-config-5.${minor}"
+                "llvm-config-${minor}"
+                "llvm-config-3.${minor}"
+                "llvm-config-mp-3.${minor}"
+                )
         endforeach ()
         find_program(LIBCLANG_LLVM_CONFIG_EXECUTABLE NAMES ${llvm_config_names})
     endif ()

--- a/sc-memory/sc-core/sc-store/sc_element.h
+++ b/sc-memory/sc-core/sc-store/sc_element.h
@@ -21,7 +21,7 @@ struct _sc_arc_info
 };
 
 
-#define SC_CHECKSUM_LEN 32//(sizeof(sc_arc_info) - sizeof(sc_uint32))
+#define SC_CHECKSUM_LEN 32 //(sizeof(sc_arc_info) - sizeof(sc_uint32))
 
 /*! Structure to store content information
  * Data field store checksum for data, that stores in specified sc-link.

--- a/sc-memory/sc-core/sc-store/sc_event/sc_event_private.h
+++ b/sc-memory/sc-core/sc-store/sc_event/sc_event_private.h
@@ -20,7 +20,6 @@
 #define SC_EVENT_REQUEST_DESTROY  (1 << 31)
 #define SC_EVENT_REF_COUNT_MASK (~SC_EVENT_REQUEST_DESTROY)
 
-#pragma pack(push, 1)
 /*! Structure that contains information about event
  */
 struct _sc_event
@@ -45,7 +44,6 @@ struct _sc_event
   sc_access_levels access_levels;
 
 };
-#pragma pack(pop)
 
 
 //! Function to initialize sc-events module

--- a/sc-memory/sc-core/sc-store/sc_event/sc_event_queue.c
+++ b/sc-memory/sc-core/sc-store/sc_event/sc_event_queue.c
@@ -11,14 +11,12 @@
 #include "../../sc_memory_private.h"
 #include "../../sc_memory.h"
 
-#pragma pack(push, 1)
 typedef struct
 {
   sc_event * evt;
   sc_addr edge_addr;
   sc_addr other_addr;
 } sc_event_pool_worker_data;
-#pragma pack(pop)
 
 sc_event_pool_worker_data * sc_event_pool_worker_data_new(sc_event * evt, sc_addr edge_addr, sc_addr other_addr)
 {

--- a/sc-network/sctp_client/sctpClient.hpp
+++ b/sc-network/sctp_client/sctpClient.hpp
@@ -20,7 +20,6 @@ namespace sctp
 
 #define SCTP_ADDR_SIZE      (sizeof(ScRealAddr))
 
-#pragma pack(push,1)
 struct RequestHeader
 {
   sc_uint8 commandType;
@@ -75,8 +74,6 @@ struct ResultHeader
   uint32_t resultSize;
 };
 
-
-#pragma pack(pop)
 
 class Iterator
 {


### PR DESCRIPTION
Originally came from https://github.com/ShunkevichDV/sc-machine/pull/65, so the PR description is a copy-paste:

This commit was cherry-picked from github.com/ostis-dev/sc-machine (master branch) to support Apple Silicon processors (without this change, sc-machine stalls with Bus error on this hardware). Adding it would allow Macintosh users with ARM64 processors build sc-machine natively or use it inside Docker (for now, Docker arm64 build is blocked by this issue). 

❗ I am not aware of how these changes affect x86_64 architecture, it probably requires testing, but if it was merged in ostis-dev/sc-machine it's probably working correctly, right? Fixed the issues on M1 processor for me, but I still ask for additional tests on x86_64 and other ARM machines.

P.S For more info about building on macOS, check https://github.com/ostis-dev/sc-machine/issues/419, README update for building on macOS is coming soon™️ 