### PR TITLE
[cmake] CMake upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,64 +121,25 @@ if (${SC_AUTO_TEST})
 endif()
 
 # find dependencies
-if (${APPLE})
-    set(Boost_USE_STATIC_LIBS ON)
-    find_package(Boost 1.67 REQUIRED COMPONENTS filesystem python37 program_options)
+if(${UNIX})
 
-    find_package(PkgConfig REQUIRED)
-    pkg_search_module(GLIB2 REQUIRED glib-2.0)
-    pkg_search_module(GLIB2_MODULE REQUIRED gmodule-2.0)
+  find_package(Boost 1.71 REQUIRED COMPONENTS filesystem python system program_options)
 
-    set (GLIB2_LIBRARIES ${GLIB_LDFLAGS} ${GLIB2_MODULE_LDFLAGS})
+  find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 
-    if (NOT DEFINED LIBCLANG_LIBRARIES OR NOT DEFINED LIBCLANG_CXXFLAGS OR NOT DEFINED LIBCLANG_LIBDIR)
-        find_package(LibClang REQUIRED)
-    endif ()
+  find_package(RocksDB REQUIRED)
 
-    find_package(PythonLibs 3.7 REQUIRED)
-    find_package(curl REQUIRED)
+  find_package(PkgConfig REQUIRED)
+  pkg_search_module(GLIB2 REQUIRED glib-2.0)
+  pkg_search_module(GLIB2_MODULE REQUIRED gmodule-2.0)
 
-    set (LIBCURL_LIBRARIES ${CURL_LIBRARIES})
+  set(GLIB2_LIBRARIES ${GLIB_LDFLAGS} ${GLIB2_MODULE_LDFLAGS})
 
-    include_directories("${CMAKE_OSX_SYSROOT}/usr/include")
+  if (NOT DEFINED LIBCLANG_LIBRARIES OR NOT DEFINED LIBCLANG_CXXFLAGS OR NOT DEFINED LIBCLANG_LIBDIR)
+    find_package(LibClang REQUIRED)
+  endif ()
 
-elseif (${UNIX})
-    function(getLibVersion libName resultVar)
-        execute_process(COMMAND /usr/bin/dpkg -s "${libName}"
-                        COMMAND /bin/grep -oP "(?<=Version:\\s)([\\d\\.]+)(?=)"
-                        OUTPUT_VARIABLE tempVar
-                        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        set(${resultVar} ${tempVar} PARENT_SCOPE)
-    endfunction()
-
-    find_package(PythonLibs 3.4 REQUIRED)
-
-    string(REPLACE "." ";" PY_VERSION_LIST ${PYTHONLIBS_VERSION_STRING})
-    list(GET PY_VERSION_LIST 0 PY_VERSION_MAJOR)
-    list(GET PY_VERSION_LIST 1 PY_VERSION_MINOR)
-
-    set(PY_SHORT_VERSION "${PY_VERSION_MAJOR}${PY_VERSION_MINOR}")
-
-    getLibVersion(libboost-python-dev BOOST_PYTHON_VER)
-    if ("${BOOST_PYTHON_VER}" STRGREATER "1.71")
-        find_package(Boost 1.54 REQUIRED COMPONENTS filesystem python${PY_SHORT_VERSION})
-    else ()
-        find_package(Boost 1.54 REQUIRED COMPONENTS filesystem python-py${PY_SHORT_VERSION})
-    endif()
-    find_package(RocksDB REQUIRED)
-
-    include(FindPkgConfig)
-    pkg_check_modules (GLIB2 REQUIRED glib-2.0)
-    pkg_check_modules (GLIB2_MODULE REQUIRED gmodule-2.0)
-
-    set (GLIB2_INCLUDE_DIRS "${GLIB2_INCLUDE_DIRS}" "/usr/lib/x86_64-linux-gnu/glib-2.0/include/" "${GLIB2_MODULE}")
-    set (GLIB2_LIBRARIES "${GLIB2_LIBRARIES}" "${GLIB2_MODULE_LIBRARIES}")
-
-    if (NOT DEFINED LIBCLANG_LIBRARIES OR NOT DEFINED LIBCLANG_CXXFLAGS OR NOT DEFINED LIBCLANG_LIBDIR)
-        find_package(LibClang REQUIRED)
-    endif ()
-
-    pkg_check_modules(LIBCURL REQUIRED libcurl)
+  pkg_check_modules(LIBCURL REQUIRED libcurl)
 
     # for std::thread support
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
@@ -263,9 +224,7 @@ elseif (${WIN32})
             )
     file(COPY ${WIN_RUNTIME_LIBRARIES} DESTINATION "${SC_BIN_PATH}")
 #
-endif(${APPLE})
-
-message ("Python version: ${PYTHONLIBS_VERSION_STRING}")
+endif(${UNIX})
 
 configure_file(${CMAKE_CURRENT_LIST_DIR}/config/config.ini.in ${CMAKE_CURRENT_LIST_DIR}/bin/config.ini)
 

--- a/sc-memory/sc-memory/CMakeLists.txt
+++ b/sc-memory/sc-memory/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(sc-memory
       PRIVATE ${GLIB2_INCLUDE_DIRS}
       PRIVATE ${SC_MACHINE_ANTRL_DIR}/runtime/src
       PRIVATE ${SC_MEMORY_SRC}
-      PRIVATE ${PYTHON_INCLUDE_DIRS})
+      PRIVATE ${Python3_INCLUDE_DIRS})
 
 if (${WIN32})
   target_link_libraries(sc-memory
@@ -42,7 +42,7 @@ elseif (${UNIX})
                         sc-core
                         antlr4_static
                         ${LIBCURL_LIBRARIES}
-                        ${PYTHON_LIBRARIES}
+                        ${Python3_LIBRARIES}
                         ${Boost_LIBRARIES})
 endif(${WIN32})
 


### PR DESCRIPTION
Changes:
1. Upgrade CMake minimum version to 3.12 to be able to use new [FindPython3](https://cmake.org/cmake/help/latest/module/FindPython3.html) functionality. Please note that distributions with older CMake version (such as Ubuntu 18.04) are no longer supported after this change
2. Update Python inclusion logic and remove previous workarounds: basic functionality of sc-machine works fine on Ubuntu 20.04, Debian 11 and macOS 12.3, tests also pass, so it doesn't seem to break anything.
3. Unify APPLE and UNIX platform for a less repetitive build config, fix macOS's build issues due to outdated and incomplete build config. ~Additionally, `install_deps_osx.sh` update is necessary, but it will be addressed later.~ (done in https://github.com/ostis-ai/sc-machine/pull/20)

I have deleted the `-pthread` flag and it doesn't seem to affect anything when compiling with clang, testing with GCC is required (hopefully CI will get merged before this so that we would know for sure)