### PR TITLE
[docs] Update README for Intel Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ cd scripts
 cd ..
 pip3 install -r requirements.txt
 ```
-Please note: you should add Qt5 to `PATH` variable. A way to do this in default macOS shell (`zsh`):
+Please note: you should add Qt5 and LLVM to `PATH` variable. To do this, after installing dependencies execute the following commands (considering you use `zsh` as your shell):
 ```sh
-echo 'export PATH="/opt/homebrew/opt/qt@5/bin:$PATH"' >> ~/.zshrc
+echo 'export PATH="'$HOMEBREW_PREFIX'/opt/qt@5/bin:$PATH"' >> ~/.zshrc
+echo 'export PATH="'$HOMEBREW_PREFIX'/opt/llvm/bin:$PATH"' >> ~/.zshrc
 ```
 
 ## Build sc-machine


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/dev/pr.md/)
* [x] Update changelog
* [x] Update documentation


This change would allow to dynamically determine `homebrew` prefix rather than hardcoding it to Apple Silicon variant, and also adding LLVM to path can help avoiding some CMake FindLibClang errors