### PR TITLE
Paralleled build

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ echo 'export PATH="'$HOMEBREW_PREFIX'/opt/llvm/bin:$PATH"' >> ~/.zshrc
 ## Build sc-machine
 ```sh
 cd sc-machine/scripts
-./make_all.sh -DCMAKE_BUILD_TYPE=Release #use Debug for debug build
+./make_all.sh #You can also pass all CMake generation arguments there
 ```
 or, alternatively
 ```sh

--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ echo 'export PATH="'$HOMEBREW_PREFIX'/opt/llvm/bin:$PATH"' >> ~/.zshrc
 
 ## Build sc-machine
 ```sh
+cd sc-machine/scripts
+./make_all.sh -DCMAKE_BUILD_TYPE=Release #use Debug for debug build
+```
+or, alternatively
+```sh
 cd sc-machine
-mkdir build
-cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release # use Debug for debug build
-make
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j$(nproc) #-j flag for paralleled build process
 ```
 
 ## Build knowledge base (from sc-machine/kb folder):

--- a/docs/build/linux-build.md
+++ b/docs/build/linux-build.md
@@ -1,4 +1,4 @@
-This instruction made for Ubuntu.
+This instruction is intended to be used on Ubuntu.
 
 ## Clone
 
@@ -20,19 +20,21 @@ pip3 --user -r requirements.txt
 
 ```sh
 cd sc-machine
-mkdir build
-cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release # use Debug for debug build
-make
+cmake -B build -DCMAKE_BUILD_TYPE=Release # use Debug for debug build
+cmake --build build -j$(nproc)
+```
+Alternatively, you can use a script:
+```sh
+cd sc-machine
+cd scripts
+./make_all.sh #You can also pass all CMake generation arguments there
 ```
 
 To build tests run:
 ```shell
 cd sc-machine
-mkdir build
-cd build
-cmake .. -DSC_BUILD_TESTS=ON -DSC_AUTO_TEST=ON -DSC_KPM_SCP=OFF
-make
+cmake -B build -DSC_BUILD_TESTS=ON -DSC_AUTO_TEST=ON -DSC_KPM_SCP=OFF
+cmake --build build -j$(nproc)
 ```
 
 or:
@@ -46,10 +48,8 @@ cd sc-machine
 To check code with CLangFormat run:
 ```shell
 cd sc-machine
-mkdir build
-cd build
-cmake .. -DSC_CLANG_FORMAT_CODE=ON
-make clangformat_check
+cmake -B build -DSC_CLANG_FORMAT_CODE=ON
+cmake --build build --target clangformat_check
 ```
 
 or
@@ -61,8 +61,6 @@ cd sc-machine
 To format code with CLangFormat run:
 ```shell
 cd sc-machine
-mkdir build
-cd build
-cmake .. -DSC_CLANG_FORMAT_CODE=ON
-make clangformat
+cmake -B build -DSC_CLANG_FORMAT_CODE=ON
+cmake --build build --target clangformat
 ```

--- a/docs/build/osx-build.md
+++ b/docs/build/osx-build.md
@@ -8,15 +8,11 @@ cd sc-machine
 
 ## Install dependencies
 
-### Setup Java
-
-Use package: https://support.apple.com/kb/dl1572?locale=en_US
-
 ### Setup build packages with brew
 
 ```sh
 cd scripts
-./install_deps_osx.sh
+./install_deps_macOS.sh
 cd ..
 pip3 --user -r requirements.txt
 ```
@@ -25,8 +21,6 @@ pip3 --user -r requirements.txt
 
 ```sh
 cd sc-machine
-mkdir build
-cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release # use Debug for debug build
-make
+cmake -B build -DCMAKE_BUILD_TYPE=Release # use Debug for debug build
+cmake --build build -j$(nproc)
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 - **Build system**
     - update macOS install_deps script
+    - Multithreaded build process used by default
  
  - **Web**
     - Moved React web interface in a separate [new repository.](https://github.com/ostis-ai/react-sc-web-ui-template)

--- a/scripts/make_all.sh
+++ b/scripts/make_all.sh
@@ -1,8 +1,3 @@
-echo -en '\E[47;31m'"\033[1mBuild sc-machine\033[0m\n"
-tput sgr0
-
 cd ..
-mkdir -p build
-cd build
-cmake ..
-make
+cmake -B build $@
+cmake --build build -j$(nproc)


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/dev/pr.md/)
* [x] Update changelog
* [x] Update documentation

Adds `-j` flag that is passed to the `make` command, so that the compilation will be executed on all available threads. Additional refinements to the build documentation are made, mostly to avoid direct usage of `make` in the scripts (it is not considered a good practice). The change should apply transitively to most projects, including `ostis-web-platform`, through `make_all.sh`