### PR TITLE
[cmake] Compatibility with CMake<3.13 (Ubuntu 18.04)

### DIFF
--- a/scripts/make_all.sh
+++ b/scripts/make_all.sh
@@ -1,5 +1,5 @@
 cd ..
 mkdir -p build
 cd build
-cmake ..
+cmake .. $@
 make -j$(nproc)

--- a/scripts/make_all.sh
+++ b/scripts/make_all.sh
@@ -1,3 +1,5 @@
 cd ..
-cmake -B build $@
-cmake --build build -j$(nproc)
+mkdir -p build
+cd build
+cmake ..
+make -j$(nproc)


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/dev/pr.md/)
* [ ] Update changelog
* [ ] Update documentation
This change fixes compatibility with older versions of CMake shipped with Ubuntu < 19.04. Note that it needs to be reverted as soon as we drop support for Ubuntu 18.04.