### PR TITLE
Create separate CI workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,57 @@
+name: Coverage
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  run_coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        id: install_deps
+        run: scripts/install_deps_ubuntu.sh
+
+      - name: Build
+        id: run_cmake
+        env:
+          CC: "gcc"
+          CXX: "g++"
+          BUILD_TYPE: "Debug"
+          COVERAGE: ON
+          SANITIZER_TYPE: none
+        run: scripts/ci/make-tests.sh
+
+      - name: Prepare coverage
+        id: prepare_coverage
+        run: scripts/ci/prepare-coverage.sh
+
+      - name: Run tests
+        id: run_tests
+        run: scripts/ci/run-tests.sh
+
+      - name: Export coverage report
+        id: export_coverage
+        run: scripts/ci/export-coverage.sh
+
+      - name: Upload coverage report to CodeCov
+        uses: codecov/codecov-action@v2
+        with:
+          directory: ${{github.workspace}}/build
+          files: coverage.info
+          flags: unittests
+          fail_ci_if_error: true
+          name: codecov-umbrella
+          verbose: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
         id: run_cmake
         env:
           CC: ${{ matrix.config.cc }}
-          CCX: ${{ matrix.config.cxx }}
+          CXX: ${{ matrix.config.cxx }}
           BUILD_TYPE: ${{ matrix.config.build_type }}
           COVERAGE: ${{ matrix.config.coverage }}
         run: scripts/ci/make-tests.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,30 +8,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  check_pr_commits:
-    name: Check commit messages
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: GS Commit Message Checker
-        # You may pin to the exact commit or the version.
-        # uses: GsActions/commit-message-checker@9d8708beab99f811c5fe3a4f98acc4b2f2ba8496
-        uses: GsActions/commit-message-checker@v1
-        with:
-          # A regex pattern to check if a commit message is valid.
-          pattern: "((\\[(builder|changelog|ci|codegen|doc|docs|python|test|tests|memory|tools|review|refactor|git|cmake)\\])+(.)+)|(Review fixes)$"
-          # Expression flags change how the expression is interpreted.
-          flags: # optional, default is gm
-          # A error message which will be returned in case of an error.
-          error: "One of commit messages or PR title have incorrect formatting. Please read the documentation: https://github.com/ostis-ai/sc-machine/blob/main/docs/dev/pr.md"
-          # Setting this input to true will exclude the Pull Request title from the check.
-          excludeTitle: true # optional, default is false
-          # Setting this input to true will exclude the Pull Request description from the check.
-          excludeDescription: true # optional, default is false
-          # Setting this input to true will check all Pull Request commits
-          checkAllCommitMessages: true # optional, default is false
-          # you must provide GITHUB_TOKEN to this input if checkAllCommitMessages is true
-          accessToken: ${{ secrets.GITHUB_TOKEN }} # optional, default is false
   run_tests:
     name: ${{matrix.config.name}}
     runs-on: ${{matrix.config.os}}
@@ -66,10 +42,6 @@ jobs:
       - name: Install dependencies
         id: install_deps
         run: scripts/install_deps_ubuntu.sh
-
-      - name: Checking the code with clang
-        run: |
-          ./scripts/ci/check-formatting.sh
 
       - name: Build
         id: run_cmake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,7 @@ jobs:
           CXX: ${{ matrix.config.cxx }}
           BUILD_TYPE: ${{ matrix.config.build_type }}
           COVERAGE: ${{ matrix.config.coverage }}
+          SANITIZER_TYPE: none
         run: scripts/ci/make-tests.sh
 
       - name: Prepare coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,6 @@ jobs:
             build_type: "Debug",
             cc: "gcc",
             cxx: "g++",
-            coverage: "OFF"
           }
           - {
             name: "Ubuntu latest, GCC, Release",
@@ -30,7 +29,6 @@ jobs:
             build_type: "Release",
             cc: "gcc",
             cxx: "g++",
-            coverage: "ON"
           }
 
     steps:
@@ -49,31 +47,10 @@ jobs:
           CC: ${{ matrix.config.cc }}
           CXX: ${{ matrix.config.cxx }}
           BUILD_TYPE: ${{ matrix.config.build_type }}
-          COVERAGE: ${{ matrix.config.coverage }}
+          COVERAGE: OFF
           SANITIZER_TYPE: none
         run: scripts/ci/make-tests.sh
-
-      - name: Prepare coverage
-        if: ${{ matrix.config.build_type == 'Release'}}
-        id: prepare_coverage
-        run: scripts/ci/prepare-coverage.sh
 
       - name: Run tests
         id: run_tests
         run: scripts/ci/run-tests.sh
-
-      - name: Export coverage report
-        if: ${{ matrix.config.build_type == 'Release'}}
-        id: export_coverage
-        run: scripts/ci/export-coverage.sh
-
-      - name: Upload coverage report to CodeCov
-        if: ${{ matrix.config.build_type == 'Release'}}
-        uses: codecov/codecov-action@v2
-        with:
-          directory: ${{github.workspace}}/build
-          files: coverage.info
-          flags: unittests
-          fail_ci_if_error: true
-          name: codecov-umbrella
-          verbose: true

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,45 @@
+name: Sanitizers
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  run_sanitizers:
+    name: ${{ matrix.config.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { name: "Sanitizer - address", sanitizer: "address" }
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        id: install_deps
+        run: scripts/install_deps_ubuntu.sh
+
+      - name: Build
+        id: run_cmake
+        env:
+          CC: clang
+          CXX: clang++
+          BUILD_TYPE: Release
+          COVERAGE: OFF
+          SANITIZER_TYPE: ${{ matrix.config.sanitizer }}
+        run: scripts/ci/make-tests.sh
+
+      - name: Run tests
+        id: run_tests
+        run: scripts/ci/run-tests.sh

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,52 @@
+name: Style
+
+on:
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  check_pr_commits:
+    name: Check commit messages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: GS Commit Message Checker
+        # You may pin to the exact commit or the version.
+        # uses: GsActions/commit-message-checker@9d8708beab99f811c5fe3a4f98acc4b2f2ba8496
+        uses: GsActions/commit-message-checker@v1
+        with:
+          # A regex pattern to check if a commit message is valid.
+          pattern: "((\\[(builder|changelog|ci|codegen|doc|docs|python|test|tests|memory|tools|review|refactor|git|cmake)\\])+(.)+)|(Review fixes)$"
+          # Expression flags change how the expression is interpreted.
+          flags: # optional, default is gm
+          # A error message which will be returned in case of an error.
+          error: "One of commit messages or PR title have incorrect formatting. Please read the documentation: https://github.com/ostis-ai/sc-machine/blob/main/docs/dev/pr.md"
+          # Setting this input to true will exclude the Pull Request title from the check.
+          excludeTitle: true # optional, default is false
+          # Setting this input to true will exclude the Pull Request description from the check.
+          excludeDescription: true # optional, default is false
+          # Setting this input to true will check all Pull Request commits
+          checkAllCommitMessages: true # optional, default is false
+          # you must provide GITHUB_TOKEN to this input if checkAllCommitMessages is true
+          accessToken: ${{ secrets.GITHUB_TOKEN }} # optional, default is false
+
+  check_formatting:
+    name: Check formatting
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        id: install_deps
+        run: scripts/install_deps_ubuntu.sh
+
+      - name: Checking the code with clang
+        run: |
+          ./scripts/ci/check-formatting.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# SC-machine
+
+[![CI](https://github.com/ostis-ai/sc-machine/actions/workflows/main.yml/badge.svg)](https://github.com/ostis-ai/sc-machine/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/ostis-ai/sc-machine/branch/main/graph/badge.svg?token=WU8O9Z1DNL)](https://codecov.io/gh/ostis-ai/sc-machine)
 
 ## Documentation: [GitHub Pages](https://ostis-ai.github.io/sc-machine)

--- a/scripts/ci/make-tests.sh
+++ b/scripts/ci/make-tests.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 pip3 install --user -r requirements.txt
 
-cmake -B build -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DSC_COVERAGE=${COVERAGE} -DSC_AUTO_TEST=ON -DSC_BUILD_TESTS=ON
+cmake -B build -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DSC_COVERAGE=${COVERAGE} -DSC_USE_SANITIZER=${SANITIZER_TYPE} -DSC_AUTO_TEST=ON -DSC_BUILD_TESTS=ON
 echo ::group::Make
 cmake --build build -j$(nproc)
 echo ::endgroup::


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/dev/pr.md/)
* [ ] Update changelog
* [ ] Update documentation

New workflow logic:
- main - building & testing with different compilers or build types
- style - checking the PR message and code format
- coverage - collecting the coverage report and sending if to CodeCov
- sanitizers - running sanitizers

Issues:
- Fails to detect correct CXX compiler on the sanitizers workflow. This looks like a cmake/scripts issue, so it should be fixed in another PR
![image](https://user-images.githubusercontent.com/56961070/164326027-7461938d-4364-4689-b9af-5e058ab6a9b5.png)
- #44
