### PR TITLE
[tools] Add opportunity to specify a structure into this structure itself

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add default python modules paths to python initialization
 - United config file
 
+### Changed
+- Fix scs-grammar. Add opportunity to specificate a structure into this structure itself
+
+
 ## [0.6.1] - 27.04.2022
 ### Added
 - Search by template with params in C++ API

--- a/sc-memory/sc-memory/scs/scs.g4
+++ b/sc-memory/sc-memory/scs/scs.g4
@@ -66,7 +66,8 @@ contour returns [ElementHandle handle]
       $ctx->handle = m_parser->ProcessContourBegin();
     }
     { $ctx->count > 0 }?
-    ( sentence_wrap* )
+    ( (sentence_wrap
+	| (sentence_lvl_4_list_item[$ctx->handle] ';;'))* )
     CONTOUR_END
     {
       $ctx->count--;
@@ -77,7 +78,8 @@ contour returns [ElementHandle handle]
     }
   ;
 
-contourWithJoin returns [ElementHandle handle]
+contourWithJoin[ElementHandle contourHandle]
+  returns [ElementHandle handle]
   locals [int count = 0; ]
   @init{ $count = 1; }
   : CONTOUR_BEGIN
@@ -85,7 +87,8 @@ contourWithJoin returns [ElementHandle handle]
       m_parser->ProcessContourBegin();
     }
     { $ctx->count > 0 }?
-    ( sentence_wrap* )
+    ( (sentence_wrap
+	| (sentence_lvl_4_list_item[$contourHandle] ';;'))* )
     CONTOUR_END
     {
       $ctx->count--;
@@ -161,7 +164,7 @@ sentence_assign
   ;
 
 sentence_assign_contour
-  : a=idtf_system '=' i=contourWithJoin
+  : a=idtf_system '=' i=contourWithJoin[$ctx->a->handle]
     {
       m_parser->ProcessContourEndWithJoin($ctx->a->handle);
     }

--- a/tools/builder/tests/units/test_contours.cpp
+++ b/tools/builder/tests/units/test_contours.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+
+#include "builder_test.hpp"
+#include "sc-memory/sc_scs_helper.hpp"
+
+#include "tests/sc-memory/_test/dummy_file_interface.hpp"
+
+TEST_F(ScBuilderTest, contours)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+
+  std::string const scsTempl =
+      "struct1 ="
+      "[*"
+      "=> nrel_idtf:"
+      "[Identifier1] (* <- lang_en;; *);;"
+      "=> nrel_relation_1:"
+      "other;;"
+      "*];;";
+
+  EXPECT_TRUE(helper.GenerateBySCsText(scsTempl));
+  auto links = m_ctx->FindLinksByContent("Identifier1");
+  EXPECT_FALSE(links.empty());
+
+  ScAddr const structAddr = m_ctx->HelperFindBySystemIdtf("struct1");
+  ScTemplate templ;
+  templ.TripleWithRelation(
+      structAddr,
+      ScType::EdgeDCommonVar,
+      ScType::LinkVar >> "_link",
+      ScType::EdgeAccessVarPosPerm,
+      m_ctx->HelperFindBySystemIdtf("nrel_idtf"));
+
+  ScTemplateSearchResult result;
+  m_ctx->HelperSearchTemplate(templ, result);
+  EXPECT_FALSE(result.IsEmpty());
+
+  ScAddr found;
+  for (auto const & item : links)
+  {
+    if (item == result[0]["_link"])
+    {
+      found = item;
+      break;
+    }
+  }
+  EXPECT_TRUE(found.IsValid());
+  EXPECT_TRUE(m_ctx->HelperCheckEdge(m_ctx->HelperFindBySystemIdtf("lang_en"), found, ScType::EdgeAccessConstPosPerm));
+
+  EXPECT_TRUE(m_ctx->HelperCheckEdge(structAddr, m_ctx->HelperFindBySystemIdtf("other"), ScType::EdgeDCommonConst));
+}


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/dev/pr.md/)
* [x] Update changelog
* [x] Update documentation

This fix in scs-grammar allows to write scs, like as:

struct1
[*
=>nrel_idtf:
[Identifier1];;
*];;

PR solve #40 issue.