### PR TITLE
[memory] Remove explicit in ScTemplateResult bool operator

### DIFF
--- a/sc-memory/sc-memory/sc_template.hpp
+++ b/sc-memory/sc-memory/sc_template.hpp
@@ -260,7 +260,7 @@ public:
     {
     }
 
-    explicit operator bool() const
+    operator bool() const
     {
       return m_result;
     }


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/dev/pr.md/)

Not to use (bool) in every converting types usages
