### PR TITLE
Exclude syntax for repo.path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,18 @@ To get more information, use `python3 scripts/build_kb.py -h`
 
 **Note: flags have higher priority than config file.**
 
+For more complex KB setups (with several folders across the filesystem, for example), we've created an internal file format called `repo.path`. It allows you to specify all the folders that should be built into the KB or exclude some files or subfolders
 ### repo.path example
 ```sh
 # Comments should start with hashtag as a first character in the line
 # Here you can specify path to one or several kb folders
 # Paths can be relative
 ../ims.ostis.kb
-#../custom_kb
+/full/path/to/kb
+../custom_kb
+# you can also exclude files or folders by adding a "!" symbol at the beginning of the line
+!../ims.ostis.kb/ims/ostis_tech
+!../custom_kb/test.scs
 ```
 
 ## Servers

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `;` after `SC_ASSERT` calls in projects that use sc-machine
 
 ### Added
+- Excludes for files and folders in repo.path
 - Automatic usage of ccache to speed up builds
 - Add ci for `rocksdb` and `sc-dictionary`
 - Implement `sc-dictionary`. Add opportunity to switch `rocksdb` and `sc-dictionary`

--- a/scripts/build_kb.py
+++ b/scripts/build_kb.py
@@ -7,8 +7,9 @@ import configparser
 
 FILENAME = "repo.path"
 paths = set()
-
-#A dir that contains the dir that contains this script - so that sc-machine/scripts/build_kb.py would become sc-machine
+exclude_paths = set()
+exclude_patterns = frozenset([".git*"])
+# A dir that contains the dir that contains this script - so that sc-machine/scripts/build_kb.py would become sc-machine
 ostis_path = abspath(join(os.path.dirname(os.path.realpath(__file__)), "../"))
 
 kb_scripts_path = join(ostis_path, "scripts/kb_scripts")
@@ -33,21 +34,40 @@ def search_knowledge_bases(root_path: str):
     elif isfile(root_path):
         with open(join(root_path), 'r') as root_file:
             for line in root_file.readlines():
+                # ignore comments and empty lines
                 line = line.replace('\n', '')
-                absolute_path = abspath(join(dirname(root_path), line))
                 # note: with current implementation, line is considered a comment if it's the first character in the line
-                #ignore paths we've already checked, comments and empty lines
-                if absolute_path in paths or line.startswith('#') or re.match(r"^\s*$", line):
+                if line.startswith('#') or re.match(r"^\s*$", line):
                     continue
+                elif line.startswith('!'):
+                    absolute_path = abspath(join(dirname(root_path), line[1:]))
+                    exclude_paths.add(absolute_path)
                 else:
-                    #recursively check each repo entry
-                    search_knowledge_bases(absolute_path)
+                    absolute_path = abspath(join(dirname(root_path), line))
+                    # ignore paths we've already checked
+                    if absolute_path not in paths:
+                        # recursively check each repo entry
+                        search_knowledge_bases(absolute_path)
                     
 
     else:
         print("Folder", root_path, "is not found.")
         exit(1)
 
+# return a file/dir name if it shouldn't be copied (returns .git folder and paths inside exclude_paths)
+def ignore_files(directory, contents):
+    ignored_files = set()
+    # for each ignored path
+    for path in exclude_paths:
+        # check if a child of this folder is inside the excluded path
+        for f in contents:
+            if abspath(join(directory, f)) == path:
+                ignored_files.add(f)
+            # ignore glob patterns defined in exclude_patterns using shutil.ignore_patterns func factory
+            ignored_files.update(shutil.ignore_patterns(*exclude_patterns)(directory, contents))
+            
+    # return a set of filenames that should be excluded
+    return ignored_files
 
 def copy_kb(output_path: str):
     prepared_kb = join(output_path, "prepared_kb")
@@ -55,9 +75,9 @@ def copy_kb(output_path: str):
         common_prefix = commonprefix(list(paths))
         for path in paths:
             # removes the common part from paths and copies what's left to prepared_kb
-            # TODO: ignore .git folder inside kb folders 
+            # unless the file/folder is in excluded_paths 
             shutil.copytree(path, join(prepared_kb, relpath(
-                path, common_prefix)), dirs_exist_ok=True)
+                path, common_prefix)), ignore=ignore_files, dirs_exist_ok=True)
     except Exception as e:
         print(e)
 
@@ -65,9 +85,10 @@ def copy_kb(output_path: str):
 def parse_config(path: str) -> dict:
     config_dict = {REPO_FILE: '', OUTPUT_PATH: '', LOGFILE_PATH: ''}
     config = configparser.ConfigParser()
-    config.read(path)
-    config_dict.update({'output_path': abspath(join(dirname(path), config['Repo']['Path']))})
-    config_dict.update({'errors_file_path': abspath(join(dirname(path), config['Repo']['Logfile'], "prepare.log"))})
+    if path != None:
+        config.read(path)
+        config_dict.update({'output_path': abspath(join(dirname(path), config['Repo']['Path']))})
+        config_dict.update({'errors_file_path': abspath(join(dirname(path), config['Repo']['Logfile'], "prepare.log"))})
 
     return config_dict
 
@@ -91,9 +112,9 @@ def build_kb(bin_folder: str, kb_to_build: str):
 def main(args: dict):
     conf = parse_config(args["config_file_path"])
 
-    #absolutize paths passed as flags
+    # absolutize paths passed as flags
 
-    #rewrite options which were given by flags
+    # rewrite options which were given by flags
      
     for key in args.keys():
         if args[key] is not None:
@@ -105,7 +126,7 @@ def main(args: dict):
     # output the final configuration for the script, just to be sure about what's going on.
     print("args:", conf)
 
-    #prepared_kb will appear in the same folder as kb.bin
+    # prepared_kb will appear in the same folder as kb.bin
     kb_to_prepare = join(conf["output_path"], "prepared_kb")
     if isdir(kb_to_prepare):
         shutil.rmtree(kb_to_prepare)
@@ -139,5 +160,5 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    #convert args from namespace to a dict
+    # convert args from namespace to a dict
     main(vars(args))


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/dev/pr.md/)
* [x] Update changelog
* [x] Update documentation

The change is very straightforward: you can use `!` symbol in `repo.path` to exclude a file (or folder) from being prepared and built into the knowledge base.

Example repo.path:
```
./ims.ostis.kb
!./ims.ostis.kb/ims/OSTIS_technology.scs
./sc-web/components/scg/kb
!./ims.ostis.kb/docs
```

There's only one question left: I haven't found any documentation about repo.path, so I couldn't add the information about the new syntax. If there's none, should we create it?