### PR TITLE
Fix make_all.sh

### DIFF
--- a/scripts/make_all.sh
+++ b/scripts/make_all.sh
@@ -1,3 +1,3 @@
 APP_ROOT_PATH=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd)
-cmake -B ${APP_ROOT_PATH}/build $@
+cmake -B ${APP_ROOT_PATH}/build ${APP_ROOT_PATH} $@
 cmake --build ${APP_ROOT_PATH}/build -j$(nproc)


### PR DESCRIPTION
This change would fix the problem that `make_all.sh` was only usable in the root folder of the project, because now it doesn't rely on the current working directory to find the root `CMakeLists.txt` file.