### PR TITLE
Use negation in scs five-element statements

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - United config file
 
 ### Changed
+- Use negate links in scs five-element statement "<source> => <rel>|: <target>;;"
 - Up codecov target from 40% to 60%
 - Separate ci workflow: check pr-commit, codestyle and tests
 - Revamped README.md

--- a/sc-memory/sc-memory/scs/scs.g4
+++ b/sc-memory/sc-memory/scs/scs.g4
@@ -19,7 +19,7 @@ tokens
 #define APPEND_ATTRS(__attrs, __edge) \
 for (auto const & _a : __attrs) \
 { \
-  ElementHandle const attrEdge = m_parser->ProcessConnector(_a.second ? "->" : "_->"); \
+  ElementHandle const attrEdge = m_parser->ProcessConnector(_a.second); \
   m_parser->ProcessTriple(_a.first, attrEdge, __edge); \
 }
 
@@ -340,14 +340,14 @@ sentence_lvl_common
     (';' sentence_lvl_4_list_item[$ctx->src->handle])*
   ;
 
-attr_list returns [std::vector<std::pair<ElementHandle, bool>> items]
+attr_list returns [std::vector<std::pair<ElementHandle, std::string>> items]
   @init { $items = {}; }
   : (
       ID_SYSTEM
       EDGE_ATTR
       {
         $ctx->items.emplace_back(m_parser->ProcessIdentifier($ID_SYSTEM->getText()),
-                                 scs::TypeResolver::IsEdgeAttrConst($EDGE_ATTR->getText()));
+                                 scs::TypeResolver::GetEdgeAttr($EDGE_ATTR->getText()));
       }
     )+
   ;
@@ -393,7 +393,8 @@ LINK
   
 EDGE_ATTR
   : ':'
-  | '::';
+  | '::'
+  | '|:';
 
 LINE_TERMINATOR
   : [\r\n\u2028\u2029] -> channel(HIDDEN)

--- a/sc-memory/sc-memory/scs/scs_types.cpp
+++ b/sc-memory/sc-memory/scs/scs_types.cpp
@@ -10,6 +10,12 @@
 namespace scs
 {
 
+std::unordered_map<std::string, std::string> TypeResolver::ms_attrToEdgeType = {
+    {":", "->"},
+    {"::", "_->"},
+    {"|:", "-|>"},
+};
+
 TypeResolver::MapType TypeResolver::ms_connectorToType = {
     {">", ScType::EdgeDCommon},
     {"<", ScType::EdgeDCommon},
@@ -103,9 +109,10 @@ bool TypeResolver::IsConst(std::string const & idtf)
   return (idtf[i] != '_');
 }
 
-bool TypeResolver::IsEdgeAttrConst(std::string const & attr)
+std::string TypeResolver::GetEdgeAttr(std::string const & attr)
 {
-  return (attr == ":");
+  auto const & it = ms_attrToEdgeType.find(attr);
+  return it->second;
 }
 
 bool TypeResolver::IsKeynodeType(std::string const & alias)

--- a/sc-memory/sc-memory/scs/scs_types.hpp
+++ b/sc-memory/sc-memory/scs/scs_types.hpp
@@ -20,7 +20,7 @@ public:
 
   static bool IsConnectorReversed(std::string const & connectorAlias);
   static bool IsConst(std::string const & idtf);
-  static bool IsEdgeAttrConst(std::string const & attr);
+  static std::string GetEdgeAttr(std::string const & attr);
   static bool IsKeynodeType(std::string const & alias);
   static bool IsUnnamed(std::string const & alias);
 
@@ -28,6 +28,7 @@ private:
   using MapType = std::unordered_map<std::string, ScType>;
   using IsType = std::unordered_set<std::string>;
 
+  static std::unordered_map<std::string, std::string> ms_attrToEdgeType;
   static MapType ms_keynodeToType;
   static MapType ms_connectorToType;
   static IsType ms_reversedConnectors;

--- a/sc-memory/tests/scs/units/test_scs_level_5.cpp
+++ b/sc-memory/tests/scs/units/test_scs_level_5.cpp
@@ -45,3 +45,54 @@ TEST(scs_level_5, simple)
 
   EXPECT_EQ(triples[3].m_target, triples[2].m_edge);
 }
+
+TEST(scs_level_5, attrs)
+{
+  std::string const data =
+      "set1 => attr1: item1;;"
+      "set2 => attr2:: item2;;"
+      "set3 => attr3|: item3;;";
+
+  scs::Parser parser;
+
+  EXPECT_TRUE(parser.Parse(data));
+
+  TripleTester tester(parser);
+  tester({
+      {
+          { ScType::NodeConst, "set1" },
+          { ScType::EdgeDCommonConst, scs::Visibility::Local },
+          { ScType::NodeConst, "item1" }
+      },
+      {
+          { ScType::NodeConst, "attr1" },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::EdgeDCommonConst, scs::Visibility::Local }
+      },
+      {
+          { ScType::NodeConst, "set2" },
+          { ScType::EdgeDCommonConst, scs::Visibility::Local },
+          { ScType::NodeConst, "item2" }
+      },
+      {
+          { ScType::NodeConst, "attr2" },
+          { ScType::EdgeAccessVarPosPerm, scs::Visibility::Local },
+          { ScType::EdgeDCommonConst, scs::Visibility::Local }
+      },
+      {
+          { ScType::NodeConst, "set3" },
+          { ScType::EdgeDCommonConst, scs::Visibility::Local },
+          { ScType::NodeConst, "item3" }
+      },
+      {
+          { ScType::NodeConst, "attr3" },
+          { ScType::EdgeAccessConstNegPerm, scs::Visibility::Local },
+          { ScType::EdgeDCommonConst, scs::Visibility::Local }
+      }
+  });
+
+  auto const & triples = parser.GetParsedTriples();
+  EXPECT_EQ(triples.size(), 6u);
+
+  EXPECT_EQ(triples[3].m_target, triples[2].m_edge);
+}


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/dev/pr.md/)
* [x] Update changelog
* [x] Update documentation

Extend 5 level of scs and allow to use statement as <source> => <rel>|: <target> to negate belonging to relation.