### PR TITLE
[memory][dictionary] Find links by substring, not by substring prefix, implement find strings by substring, add remove links contents

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Implement sc-link content removing from sc-storage
 - Add command to find links contents by content substring into sc-server
-- Implement find links contents by content substring and sc-server
-- Ci for docker build and run
-- Ci for ubuntu-22.04 and latest macOS
+- Implement find links contents by content substring into sc-server
+- CI for docker build and run
+- CI for ubuntu-22.04 and latest macOS
 - Add ScExec class to execute system commands
 - Test for utils for work with actions and their results
 - Handle and save sc-server subcommands errors
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add tests for sc-search agents in sc-kpm
 - Write sc-machine idea into readme
 - Add create elements by scs-helper through sc-server
-- Add ci workflow for sanitizers
+- Add CI workflow for sanitizers
 - Add find links by substring in sc-server
 - Initial development container support
 - You can now run sc-machine in Docker
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add opportunity to search sc-links in `sc-dictionary` by content substr
 - Excludes for files and folders in repo.path
 - Automatic usage of ccache to speed up builds
-- Add ci for `rocksdb` and `sc-dictionary`
+- Add CI for `rocksdb` and `sc-dictionary`
 - Implement `sc-dictionary`. Add opportunity to switch `rocksdb` and `sc-dictionary`
 - Wrap and separate allocating, assertion, notification and atomic lock free procedures
 - Add tests module for sc-agents-utils

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Implement sc-link content removing from sc-storage
+- Add command to find links contents by content substring into sc-server
+- Implement find links contents by content substring and sc-server
+- Ci for docker build and run
 - Ci for ubuntu-22.04 and latest macOS
 - Add ScExec class to execute system commands
 - Test for utils for work with actions and their results
@@ -47,6 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fix sc-server json casts to strings
+- Check sc-server run in tests
+- Flag --tests for sc-server to run and quick stop it
 - Fix glib casts on ubuntu-20.04 and macOS
 - Store binary content as base64 string
 - Update action utils to use the new logic for waiting for action results
@@ -69,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove find by substring logic from sc-dictionary
 - Remove legacy gwf-translator for 0.3.0 gwf sources from sc-builder
 - Remove legacy glib-based tests
 - Remove boost usage for options parsing in sc-server and sc-builder

--- a/docs/sc-network/sc_json.g4
+++ b/docs/sc-network/sc_json.g4
@@ -209,9 +209,14 @@ sc_json_command_handle_link_contents
          '}' ','
          |
          '{'
-              '"command' ':' '"find_by_substr"' ','
+              '"command' ':' '"find_links_by_substr"' ','
 			  '"data"' ':' NUMBER_CONTENT | STRING_CONTENT ','
           '}' ','
+         |
+         '{'
+              '"command' ':' '"find_strings_by_substr"' ','
+              '"data"' ':' NUMBER_CONTENT | STRING_CONTENT ','
+         '}' ','
      )*']' ','
   ;
 

--- a/docs/storage/sc-dictionary.md
+++ b/docs/storage/sc-dictionary.md
@@ -71,12 +71,6 @@ Common API methods of sc-dictionary implementation and their description are rep
   </tr>
 
   <tr>
-    <td>sc_list * sc_dictionary_get_by_substr(sc_dictionary * dictionary, const sc_char * sc_substr)</td>
-    <td>It gets data or data array by key substring, that is a prefix of found links contents. If sc-dictionary has not such key string, 
-        then method returns empty sc-list.</td>
-  </tr>
-
-  <tr>
     <td>void sc_dictionary_visit_down_nodes(sc_dictionary * dictionary, void (*callable)(sc_dictionary_node *, void **), void ** dest)</td>
     <td>It visits up down all nodes and call specified routine for them. A result of procedure completion saves into 'dest'.</td>
   </tr>
@@ -117,6 +111,7 @@ int main()
     sum += v;
     std::cout << v << std::endl; 
   }
+  sc_iterator_destroy(it);
   
   sc_dictionary_destroy(dict);
   

--- a/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.c
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.c
@@ -13,19 +13,23 @@
 #include "../../sc-base/sc_allocator.h"
 #include "../../sc-container/sc-string/sc_string.h"
 
-static const sc_uint8 s_min_sc_char = 1;
-static const sc_uint8 s_max_sc_char = 255;
-
 #define SC_DICTIONARY_NODE_IS_VALID(__node) ((__node) != null_ptr)
 #define SC_DICTIONARY_NODE_IS_NOT_VALID(__node) ((__node) == null_ptr)
 
-sc_bool sc_dictionary_initialize(sc_dictionary ** dictionary)
+sc_bool sc_dictionary_initialize(
+    sc_dictionary ** dictionary,
+    sc_uint8 children_size,
+    void (*char_to_int)(sc_char, sc_uint8 *, sc_uint8 *),
+    void (*int_to_char)(sc_uint8, sc_uint8, sc_char *))
 {
   if (*dictionary != null_ptr)
     return SC_FALSE;
 
   *dictionary = sc_mem_new(sc_dictionary, 1);
-  (*dictionary)->root = _sc_dictionary_node_initialize();
+  (*dictionary)->size = children_size;
+  (*dictionary)->root = _sc_dictionary_node_initialize(children_size);
+  (*dictionary)->char_to_int = char_to_int;
+  (*dictionary)->int_to_char = int_to_char;
 
   return SC_TRUE;
 }
@@ -42,15 +46,10 @@ sc_bool sc_dictionary_destroy(sc_dictionary * dictionary, void (*node_destroy)(s
   return SC_TRUE;
 }
 
-inline sc_uint8 _sc_dictionary_children_size()
-{
-  return s_max_sc_char - s_min_sc_char + 1;
-}
-
-inline sc_dictionary_node * _sc_dictionary_node_initialize()
+inline sc_dictionary_node * _sc_dictionary_node_initialize(sc_uint8 children_size)
 {
   sc_dictionary_node * node = sc_mem_new(sc_dictionary_node, 1);
-  node->next = sc_mem_new(sc_dictionary_node *, _sc_dictionary_children_size());
+  node->next = sc_mem_new(sc_dictionary_node *, children_size);
 
   node->data_list = null_ptr;
   node->offset = null_ptr;
@@ -79,16 +78,18 @@ void sc_dictionary_node_destroy(sc_dictionary_node * node, void ** args)
   sc_mem_free(node);
 }
 
-inline sc_dictionary_node * _sc_dictionary_get_next_node(sc_dictionary_node * node, sc_char ch)
+inline sc_dictionary_node * _sc_dictionary_get_next_node(sc_dictionary * dictionary, sc_dictionary_node * node, sc_char ch)
 {
   sc_uint8 num;
-  sc_char_to_sc_int(ch, &num, &node->mask);
+  dictionary->char_to_int(ch, &num, &node->mask);
 
-  return num == 0 || node->next == null_ptr ? null_ptr : node->next[num];
+  return node->next == null_ptr ? null_ptr : node->next[num];
 }
 
-sc_dictionary_node * sc_dictionary_append_to_node(sc_dictionary_node * node, sc_char * sc_string, sc_uint32 size)
+sc_dictionary_node * sc_dictionary_append_to_node(sc_dictionary * dictionary, sc_char * sc_string, sc_uint32 size)
 {
+  sc_dictionary_node * node = dictionary->root;
+
   sc_char ** sc_string_ptr = sc_mem_new(sc_char *, 1);
   *sc_string_ptr = sc_string;
 
@@ -97,11 +98,11 @@ sc_dictionary_node * sc_dictionary_append_to_node(sc_dictionary_node * node, sc_
   while (i < size)
   {
     sc_uint8 num;
-    sc_char_to_sc_int(**sc_string_ptr, &num, &node->mask);
+    dictionary->char_to_int(**sc_string_ptr, &num, &node->mask);
     // define prefix
     if (SC_DICTIONARY_NODE_IS_NOT_VALID(node->next[num]))
     {
-      node->next[num] = _sc_dictionary_node_initialize();
+      node->next[num] = _sc_dictionary_node_initialize(dictionary->size);
 
       sc_dictionary_node * temp = node->next[num];
 
@@ -126,7 +127,7 @@ sc_dictionary_node * sc_dictionary_append_to_node(sc_dictionary_node * node, sc_
       {
         saved_offset_size = moving->offset_size;
 
-        node->next[num] = _sc_dictionary_node_initialize();
+        node->next[num] = _sc_dictionary_node_initialize(dictionary->size);
 
         sc_dictionary_node * temp = node->next[num];
 
@@ -141,7 +142,7 @@ sc_dictionary_node * sc_dictionary_append_to_node(sc_dictionary_node * node, sc_
       {
         sc_char * offset_ptr = &*(moving->offset + j);
 
-        sc_char_to_sc_int(*offset_ptr, &num, &node->mask);
+        dictionary->char_to_int(*offset_ptr, &num, &node->mask);
         node->next[num] = &*moving;
 
         sc_dictionary_node * temp = node->next[num];
@@ -164,7 +165,7 @@ sc_dictionary_node * sc_dictionary_append_to_node(sc_dictionary_node * node, sc_
 
 sc_dictionary_node * sc_dictionary_append(sc_dictionary * dictionary, sc_char * sc_string, sc_uint32 size, void * value)
 {
-  sc_dictionary_node * node = sc_dictionary_append_to_node(dictionary->root, sc_string, size);
+  sc_dictionary_node * node = sc_dictionary_append_to_node(dictionary, sc_string, size);
 
   if (node->data_list == null_ptr)
     sc_list_init(&node->data_list);
@@ -176,6 +177,7 @@ sc_dictionary_node * sc_dictionary_append(sc_dictionary * dictionary, sc_char * 
 }
 
 sc_dictionary_node * sc_dictionary_remove_from_node(
+    sc_dictionary * dictionary,
     sc_dictionary_node * node,
     sc_uint8 node_index,
     sc_dictionary_node * parent,
@@ -186,11 +188,11 @@ sc_dictionary_node * sc_dictionary_remove_from_node(
   // check prefixes matching
   sc_uint32 string_size = strlen(sc_string);
   sc_uint8 num = 0;
-  sc_char_to_sc_int(sc_string[index], &num, &node->mask);
+  dictionary->char_to_int(sc_string[index], &num, &node->mask);
   if (num != 0 && SC_DICTIONARY_NODE_IS_VALID(node->next[num]))
   {
     sc_dictionary_node * removable = sc_dictionary_remove_from_node(
-        node->next[num], num, node, sc_string, index + node->next[num]->offset_size, removable_index);
+        dictionary, node->next[num], num, node, sc_string, index + node->next[num]->offset_size, removable_index);
 
     if (SC_DICTIONARY_NODE_IS_VALID(node->next[num]))
       return removable;
@@ -218,7 +220,8 @@ sc_dictionary_node * sc_dictionary_remove_from_node(
 sc_bool sc_dictionary_remove(sc_dictionary * dictionary, const sc_char * sc_string)
 {
   sc_uint8 index = 0;
-  sc_dictionary_node * node = sc_dictionary_remove_from_node(dictionary->root, 0, null_ptr, sc_string, 0, &index);
+  sc_dictionary_node * node
+      = sc_dictionary_remove_from_node(dictionary, dictionary->root, 0, null_ptr, sc_string, 0, &index);
 
   sc_bool result = node->next[index] != null_ptr;
   if (index != 0 && result == SC_TRUE)
@@ -230,42 +233,8 @@ sc_bool sc_dictionary_remove(sc_dictionary * dictionary, const sc_char * sc_stri
   return result;
 }
 
-sc_dictionary_node * sc_dictionary_get_node_from_node(sc_dictionary_node * node, const sc_char * sc_string)
-{
-  // check prefixes matching
-  sc_uint32 i = 0;
-  sc_uint32 string_size = strlen(sc_string);
-  while (i < string_size)
-  {
-    sc_dictionary_node * next = _sc_dictionary_get_next_node(node, sc_string[i]);
-    if (SC_DICTIONARY_NODE_IS_VALID(next))
-    {
-      node = next;
-      i += node->offset_size;
-    }
-    else
-      break;
-  }
-
-  if (i <= string_size)
-  {
-    sc_char * str = sc_mem_new(sc_char, node->offset_size + 1);
-    sc_mem_cpy(str, node->offset, node->offset_size);
-
-    if (strstr(sc_string, str) != null_ptr)
-    {
-      sc_mem_free(str);
-      return node;
-    }
-
-    sc_mem_free(str);
-    return null_ptr;
-  }
-
-  return node;
-}
-
-sc_dictionary_node * sc_dictionary_get_last_node_from_node(sc_dictionary_node * node, const sc_char * sc_string)
+sc_dictionary_node * sc_dictionary_get_last_node_from_node(
+    sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string)
 {
   if (sc_string == null_ptr)
     return null_ptr;
@@ -275,7 +244,7 @@ sc_dictionary_node * sc_dictionary_get_last_node_from_node(sc_dictionary_node * 
   sc_uint32 string_size = strlen(sc_string);
   while (i < string_size)
   {
-    sc_dictionary_node * next = _sc_dictionary_get_next_node(node, sc_string[i]);
+    sc_dictionary_node * next = _sc_dictionary_get_next_node(dictionary, node, sc_string[i]);
     if (SC_DICTIONARY_NODE_IS_VALID(next))
     {
       node = next;
@@ -302,21 +271,22 @@ sc_dictionary_node * sc_dictionary_get_last_node_from_node(sc_dictionary_node * 
   return null_ptr;
 }
 
-sc_bool sc_dictionary_is_in_from_node(sc_dictionary_node * node, const sc_char * sc_string)
+sc_bool sc_dictionary_is_in_from_node(sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string)
 {
-  sc_dictionary_node * last = sc_dictionary_get_last_node_from_node(node, sc_string);
+  sc_dictionary_node * last = sc_dictionary_get_last_node_from_node(dictionary, node, sc_string);
 
   return SC_DICTIONARY_NODE_IS_VALID(last) && last->data_list != null_ptr;
 }
 
 sc_bool sc_dictionary_is_in(sc_dictionary * dictionary, const sc_char * sc_string)
 {
-  return sc_dictionary_is_in_from_node(dictionary->root, sc_string);
+  return sc_dictionary_is_in_from_node(dictionary, dictionary->root, sc_string);
 }
 
-void * sc_dictionary_get_first_data_from_node(sc_dictionary_node * node, const sc_char * sc_string)
+void * sc_dictionary_get_first_data_from_node(
+    sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string)
 {
-  sc_dictionary_node * last = sc_dictionary_get_last_node_from_node(node, sc_string);
+  sc_dictionary_node * last = sc_dictionary_get_last_node_from_node(dictionary, node, sc_string);
 
   if (SC_DICTIONARY_NODE_IS_VALID(last) && last->data_list != null_ptr && last->data_list->begin != null_ptr)
     return last->data_list->begin->data;
@@ -324,9 +294,10 @@ void * sc_dictionary_get_first_data_from_node(sc_dictionary_node * node, const s
   return null_ptr;
 }
 
-sc_list * sc_dictionary_get_datas_from_node(sc_dictionary_node * node, const sc_char * sc_string)
+sc_list * sc_dictionary_get_datas_from_node(
+    sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string)
 {
-  sc_dictionary_node * last = sc_dictionary_get_last_node_from_node(node, sc_string);
+  sc_dictionary_node * last = sc_dictionary_get_last_node_from_node(dictionary, node, sc_string);
 
   if (SC_DICTIONARY_NODE_IS_VALID(last))
     return last->data_list;
@@ -336,43 +307,13 @@ sc_list * sc_dictionary_get_datas_from_node(sc_dictionary_node * node, const sc_
 
 sc_list * sc_dictionary_get(sc_dictionary * dictionary, const sc_char * sc_string)
 {
-  return sc_dictionary_get_datas_from_node(dictionary->root, sc_string);
+  return sc_dictionary_get_datas_from_node(dictionary, dictionary->root, sc_string);
 }
 
-void _sc_dictionary_update_list(sc_dictionary_node * node, void ** args)
-{
-  if (node->data_list != null_ptr)
-  {
-    sc_list * full_list = args[0];
-
-    sc_iterator * it = sc_list_iterator(node->data_list);
-    while (sc_iterator_next(it))
-      sc_list_push_back(full_list, sc_iterator_get(it));
-
-    sc_iterator_destroy(it);
-  }
-}
-
-sc_list * sc_dictionary_get_by_substr(sc_dictionary * dictionary, const sc_char * sc_substr)
-{
-  sc_dictionary_node * node = sc_dictionary_get_node_from_node(dictionary->root, sc_substr);
-
-  sc_list * full_list;
-  sc_list_init(&full_list);
-
-  if (SC_DICTIONARY_NODE_IS_VALID(node))
-  {
-    sc_dictionary_visit_down_node_from_node(node, _sc_dictionary_update_list, (void **)&full_list);
-    _sc_dictionary_update_list(node, (void **)&full_list);
-  }
-
-  return full_list;
-}
-
-void sc_dictionary_show_from_node(sc_dictionary_node * node, sc_char * tab)
+void sc_dictionary_show_from_node(sc_dictionary * dictionary, sc_dictionary_node * node, sc_char * tab)
 {
   sc_uint8 i;
-  for (i = 1; i < _sc_dictionary_children_size(); ++i)
+  for (i = 0; i < dictionary->size; ++i)
   {
     sc_dictionary_node * next = node->next[i];
 
@@ -380,7 +321,8 @@ void sc_dictionary_show_from_node(sc_dictionary_node * node, sc_char * tab)
     {
       sc_char * str = sc_mem_new(sc_char, next->offset_size + 1);
       sc_mem_cpy(str, next->offset, next->offset_size);
-      sc_uchar ch = sc_int_to_sc_char(i, 0);
+      sc_char ch;
+      dictionary->int_to_char(i, 0, &ch);
 
       if (next->data_list != null_ptr && next->data_list->size != 0)
         printf("%s%c[%d] {%s}\n", tab, ch, next->data_list->size, str);
@@ -393,7 +335,7 @@ void sc_dictionary_show_from_node(sc_dictionary_node * node, sc_char * tab)
       strcpy(new_tab, tab);
       strcat(new_tab, "|----\0");
 
-      sc_dictionary_show_from_node(next, new_tab);
+      sc_dictionary_show_from_node(dictionary, next, new_tab);
 
       sc_mem_free(new_tab);
     }
@@ -403,24 +345,25 @@ void sc_dictionary_show_from_node(sc_dictionary_node * node, sc_char * tab)
 void sc_dictionary_show(sc_dictionary * dictionary)
 {
   printf("----------------sc-dictionary----------------\n");
-  sc_dictionary_show_from_node(dictionary->root, "\0");
+  sc_dictionary_show_from_node(dictionary, dictionary->root, "\0");
   printf("---------------------------------------------\n");
 }
 
 void sc_dictionary_visit_down_node_from_node(
+    sc_dictionary * dictionary,
     sc_dictionary_node * node,
     void (*callable)(sc_dictionary_node *, void **),
     void ** dest)
 {
   sc_uint8 i;
-  for (i = 0; i < _sc_dictionary_children_size(); ++i)
+  for (i = 0; i < dictionary->size; ++i)
   {
     sc_dictionary_node * next = node->next[i];
     if (SC_DICTIONARY_NODE_IS_VALID(next))
     {
       callable(next, dest);
 
-      sc_dictionary_visit_down_node_from_node(next, callable, dest);
+      sc_dictionary_visit_down_node_from_node(dictionary, next, callable, dest);
     }
   }
 }
@@ -430,21 +373,22 @@ void sc_dictionary_visit_down_nodes(
     void (*callable)(sc_dictionary_node *, void **),
     void ** dest)
 {
-  sc_dictionary_visit_down_node_from_node(dictionary->root, callable, dest);
+  sc_dictionary_visit_down_node_from_node(dictionary, dictionary->root, callable, dest);
 }
 
 void sc_dictionary_visit_up_node_from_node(
+    sc_dictionary * dictionary,
     sc_dictionary_node * node,
     void (*callable)(sc_dictionary_node *, void **),
     void ** dest)
 {
   sc_uint8 i;
-  for (i = 0; i < _sc_dictionary_children_size(); ++i)
+  for (i = 0; i < dictionary->size; ++i)
   {
     sc_dictionary_node * next = node->next[i];
     if (SC_DICTIONARY_NODE_IS_VALID(next))
     {
-      sc_dictionary_visit_up_node_from_node(next, callable, dest);
+      sc_dictionary_visit_up_node_from_node(dictionary, next, callable, dest);
 
       callable(next, dest);
     }
@@ -456,16 +400,5 @@ void sc_dictionary_visit_up_nodes(
     void (*callable)(sc_dictionary_node *, void **),
     void ** dest)
 {
-  sc_dictionary_visit_up_node_from_node(dictionary->root, callable, dest);
-}
-
-inline void sc_char_to_sc_int(sc_char ch, sc_uint8 * ch_num, sc_uint8 * mask)
-{
-  // @todo: Implement mask setups for rights checking and memory optimization
-  *ch_num = 128 + (sc_uint8)ch;
-}
-
-inline sc_char sc_int_to_sc_char(sc_uint8 num, sc_uint8 mask)
-{
-  return (sc_char)(num - 128);
+  sc_dictionary_visit_up_node_from_node(dictionary, dictionary->root, callable, dest);
 }

--- a/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.c
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.c
@@ -252,7 +252,7 @@ sc_dictionary_node * sc_dictionary_get_node_from_node(sc_dictionary_node * node,
     sc_char * str = sc_mem_new(sc_char, node->offset_size + 1);
     sc_mem_cpy(str, node->offset, node->offset_size);
 
-    if (strstr(str, sc_string + (string_size - node->offset_size)) != null_ptr)
+    if (strstr(sc_string, str) != null_ptr)
     {
       sc_mem_free(str);
       return node;

--- a/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.c
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.c
@@ -78,7 +78,10 @@ void sc_dictionary_node_destroy(sc_dictionary_node * node, void ** args)
   sc_mem_free(node);
 }
 
-inline sc_dictionary_node * _sc_dictionary_get_next_node(sc_dictionary * dictionary, sc_dictionary_node * node, sc_char ch)
+inline sc_dictionary_node * _sc_dictionary_get_next_node(
+    sc_dictionary * dictionary,
+    sc_dictionary_node * node,
+    sc_char ch)
 {
   sc_uint8 num;
   dictionary->char_to_int(ch, &num, &node->mask);
@@ -220,8 +223,8 @@ sc_dictionary_node * sc_dictionary_remove_from_node(
 sc_bool sc_dictionary_remove(sc_dictionary * dictionary, const sc_char * sc_string)
 {
   sc_uint8 index = 0;
-  sc_dictionary_node * node
-      = sc_dictionary_remove_from_node(dictionary, dictionary->root, 0, null_ptr, sc_string, 0, &index);
+  sc_dictionary_node * node =
+      sc_dictionary_remove_from_node(dictionary, dictionary->root, 0, null_ptr, sc_string, 0, &index);
 
   sc_bool result = node->next[index] != null_ptr;
   if (index != 0 && result == SC_TRUE)
@@ -234,7 +237,9 @@ sc_bool sc_dictionary_remove(sc_dictionary * dictionary, const sc_char * sc_stri
 }
 
 sc_dictionary_node * sc_dictionary_get_last_node_from_node(
-    sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string)
+    sc_dictionary * dictionary,
+    sc_dictionary_node * node,
+    const sc_char * sc_string)
 {
   if (sc_string == null_ptr)
     return null_ptr;
@@ -284,7 +289,9 @@ sc_bool sc_dictionary_is_in(sc_dictionary * dictionary, const sc_char * sc_strin
 }
 
 void * sc_dictionary_get_first_data_from_node(
-    sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string)
+    sc_dictionary * dictionary,
+    sc_dictionary_node * node,
+    const sc_char * sc_string)
 {
   sc_dictionary_node * last = sc_dictionary_get_last_node_from_node(dictionary, node, sc_string);
 
@@ -295,7 +302,9 @@ void * sc_dictionary_get_first_data_from_node(
 }
 
 sc_list * sc_dictionary_get_datas_from_node(
-    sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string)
+    sc_dictionary * dictionary,
+    sc_dictionary_node * node,
+    const sc_char * sc_string)
 {
   sc_dictionary_node * last = sc_dictionary_get_last_node_from_node(dictionary, node, sc_string);
 

--- a/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.c
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.c
@@ -4,7 +4,6 @@
  * (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
  */
 
-#include <stdio.h>
 #include <ctype.h>
 
 #include "sc_dictionary.h"
@@ -19,8 +18,7 @@
 sc_bool sc_dictionary_initialize(
     sc_dictionary ** dictionary,
     sc_uint8 children_size,
-    void (*char_to_int)(sc_char, sc_uint8 *, sc_uint8 *),
-    void (*int_to_char)(sc_uint8, sc_uint8, sc_char *))
+    void (*char_to_int)(sc_char, sc_uint8 *, sc_uint8 *))
 {
   if (*dictionary != null_ptr)
     return SC_FALSE;
@@ -29,7 +27,6 @@ sc_bool sc_dictionary_initialize(
   (*dictionary)->size = children_size;
   (*dictionary)->root = _sc_dictionary_node_initialize(children_size);
   (*dictionary)->char_to_int = char_to_int;
-  (*dictionary)->int_to_char = int_to_char;
 
   return SC_TRUE;
 }
@@ -271,16 +268,11 @@ sc_dictionary_node * sc_dictionary_get_last_node_from_node(
   return null_ptr;
 }
 
-sc_bool sc_dictionary_is_in_from_node(sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string)
-{
-  sc_dictionary_node * last = sc_dictionary_get_last_node_from_node(dictionary, node, sc_string);
-
-  return SC_DICTIONARY_NODE_IS_VALID(last) && last->data_list != null_ptr;
-}
-
 sc_bool sc_dictionary_is_in(sc_dictionary * dictionary, const sc_char * sc_string)
 {
-  return sc_dictionary_is_in_from_node(dictionary, dictionary->root, sc_string);
+  sc_dictionary_node * last = sc_dictionary_get_last_node_from_node(dictionary, dictionary->root, sc_string);
+
+  return SC_DICTIONARY_NODE_IS_VALID(last) && last->data_list != null_ptr;
 }
 
 void * sc_dictionary_get_first_data_from_node(
@@ -296,61 +288,14 @@ void * sc_dictionary_get_first_data_from_node(
   return null_ptr;
 }
 
-sc_list * sc_dictionary_get_datas_from_node(
-    sc_dictionary * dictionary,
-    sc_dictionary_node * node,
-    const sc_char * sc_string)
+sc_list * sc_dictionary_get(sc_dictionary * dictionary, const sc_char * sc_string)
 {
-  sc_dictionary_node * last = sc_dictionary_get_last_node_from_node(dictionary, node, sc_string);
+  sc_dictionary_node * last = sc_dictionary_get_last_node_from_node(dictionary, dictionary->root, sc_string);
 
   if (SC_DICTIONARY_NODE_IS_VALID(last))
     return last->data_list;
 
   return null_ptr;
-}
-
-sc_list * sc_dictionary_get(sc_dictionary * dictionary, const sc_char * sc_string)
-{
-  return sc_dictionary_get_datas_from_node(dictionary, dictionary->root, sc_string);
-}
-
-void sc_dictionary_show_from_node(sc_dictionary * dictionary, sc_dictionary_node * node, sc_char * tab)
-{
-  sc_uint8 i;
-  for (i = 0; i < dictionary->size; ++i)
-  {
-    sc_dictionary_node * next = node->next[i];
-
-    if (SC_DICTIONARY_NODE_IS_VALID(next))
-    {
-      sc_char * str = sc_mem_new(sc_char, next->offset_size + 1);
-      sc_mem_cpy(str, next->offset, next->offset_size);
-      sc_char ch;
-      dictionary->int_to_char(i, 0, &ch);
-
-      if (next->data_list != null_ptr && next->data_list->size != 0)
-        printf("%s%c[%d] {%s}\n", tab, ch, next->data_list->size, str);
-      else
-        printf("%s%c {%s}\n", tab, ch, str);
-
-      sc_mem_free(str);
-
-      sc_char * new_tab = sc_mem_new(sc_char, strlen(tab) + 6);
-      strcpy(new_tab, tab);
-      strcat(new_tab, "|----\0");
-
-      sc_dictionary_show_from_node(dictionary, next, new_tab);
-
-      sc_mem_free(new_tab);
-    }
-  }
-}
-
-void sc_dictionary_show(sc_dictionary * dictionary)
-{
-  printf("----------------sc-dictionary----------------\n");
-  sc_dictionary_show_from_node(dictionary, dictionary->root, "\0");
-  printf("---------------------------------------------\n");
 }
 
 void sc_dictionary_visit_down_node_from_node(

--- a/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.h
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.h
@@ -138,7 +138,9 @@ sc_bool sc_dictionary_is_in(sc_dictionary * dictionary, const sc_char * sc_strin
  * @returns Returns A sc-dictionary node where string ends
  */
 sc_dictionary_node * sc_dictionary_get_last_node_from_node(
-    sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string);
+    sc_dictionary * dictionary,
+    sc_dictionary_node * node,
+    const sc_char * sc_string);
 
 /*! Gets first data from a terminal sc-dictionary node where string ends.
  * @param dictionary A sc-dictionary pointer
@@ -147,7 +149,9 @@ sc_dictionary_node * sc_dictionary_get_last_node_from_node(
  * @returns Returns Data from a sc-dictionary node where string ends
  */
 void * sc_dictionary_get_first_data_from_node(
-    sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string);
+    sc_dictionary * dictionary,
+    sc_dictionary_node * node,
+    const sc_char * sc_string);
 
 /*! Gets datas from a terminal sc-dictionary node where string ends.
  * @param dictionary A sc-dictionary pointer
@@ -156,7 +160,9 @@ void * sc_dictionary_get_first_data_from_node(
  * @returns Returns Datas from a sc-dictionary node where string ends
  */
 sc_list * sc_dictionary_get_datas_from_node(
-    sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string);
+    sc_dictionary * dictionary,
+    sc_dictionary_node * node,
+    const sc_char * sc_string);
 
 /*! Gets datas from a terminal sc-dictionary node where string ends.
  * @param dictionary A sc-dictionary pointer

--- a/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.h
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.h
@@ -39,21 +39,18 @@ typedef struct _sc_dictionary
   sc_dictionary_node * root;  // sc-dictionary tree root node
   sc_uint8 size;              // default sc-dictionary node children size
   void (*char_to_int)(sc_char, sc_uint8 *, sc_uint8 *);
-  void (*int_to_char)(sc_uint8, sc_uint8, sc_char *);
 } sc_dictionary;
 
 /*! Initializes sc-dictionary
  * @param[out] dictionary Pointer to a sc-dictionary pointer to initialize
  * @param[in] children_size SC-dictionary node children count
  * @param[in] char_to_int Pointer to function that converts sc_char to sc_uint8 and returns sc_uint8 mask
- * @param[in] int_to_char Pointer to function that converts sc_uint8 with sc_uint8 mask to sc_char
  * @returns Returns SC_TRUE, if sc-dictionary didn't exist; otherwise return SC_FALSE.
  */
 sc_bool sc_dictionary_initialize(
     sc_dictionary ** dictionary,
     sc_uint8 children_size,
-    void (*char_to_int)(sc_char, sc_uint8 *, sc_uint8 *),
-    void (*int_to_char)(sc_uint8, sc_uint8, sc_char *));
+    void (*char_to_int)(sc_char, sc_uint8 *, sc_uint8 *));
 
 /*! Destroys a sc-dictionary
  * @param dictionary A sc-dictionary pointer to destroy
@@ -67,18 +64,6 @@ sc_bool sc_dictionary_destroy(sc_dictionary * dictionary, void (*node_destroy)(s
  * @param args An additional args used with node destroying
  */
 void sc_dictionary_node_destroy(sc_dictionary_node * node, void ** args);
-
-/*! Appends a string to a sc-dictionary by a common prefix with another string started in sc-dictionary node, if such
- * exists.
- * @param dictionary A sc-dictionary pointer
- * @param sc_string An appendable string
- * @param size An appendable string size
- * @returns Returns A sc-dictionary node where appended string is ended
- */
-sc_dictionary_node * sc_dictionary_append_to_node(
-    sc_dictionary * dictionary,
-    const sc_char * sc_string,
-    sc_uint32 size);
 
 /*! Appends a string to a sc-dictionary by a common prefix with another string started in sc-dictionary node, if such
  * exists. In end sc-dictionary node stores pointer to data by string.
@@ -96,36 +81,12 @@ sc_dictionary_node * sc_dictionary_append(
 
 /*! Removes a string from a sc-dictionary by a common prefix with another string started in sc-dictionary node, if such
  * exists. A common prefix doesn't remove form sc-dictionary if it contains in another string.
- * @param dictionary A sc-dictionary pointer
- * @param node A sc-dictionary node where common prefix may be started
- * @param sc_string A removable string
- * @param size Removable string size
- * @returns Returns A sc-dictionary node where removable string or its prefix starts
- * @note If string isn't in sc-dictionary then null_pointer will be returned
- */
-sc_dictionary_node * sc_dictionary_remove_from_node(
-    sc_dictionary * dictionary,
-    sc_dictionary_node * node,
-    const sc_char * sc_string,
-    sc_uint32 index);
-
-/*! Removes a string from a sc-dictionary by a common prefix with another string started in sc-dictionary node, if such
- * exists. A common prefix doesn't remove form sc-dictionary if it contains in another string.
  * @param sc_dictionary A sc-dictionary where common prefix may be started
  * @param sc_string A removable string
  * @returns Returns If a string was removed then function returns SC_TRUE; otherwise return SC_FALSE.
  * @note If a string isn't in sc-dictionary then SC_FALSE will be returned
  */
 sc_bool sc_dictionary_remove(sc_dictionary * dictionary, const sc_char * sc_string);
-
-/*! Checks, if a string starts in a sc-dictionary node by a common prefix with another string started in sc-dictionary
- * node, if such exists.
- * @param dictionary A sc-dictionary pointer
- * @param node A sc-dictionary node where common prefix may be started
- * @param sc_string A verifiable string
- * @returns Returns SC_TRUE, if string starts in sc-dictionary node; otherwise return SC_FALSE.
- */
-sc_bool sc_dictionary_is_in_from_node(sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string);
 
 /*! Checks, if a string is in a sc-dictionary by a common prefix with another string started in sc-dictionary
  * node, if such exists.
@@ -134,17 +95,6 @@ sc_bool sc_dictionary_is_in_from_node(sc_dictionary * dictionary, sc_dictionary_
  * @returns Returns SC_TRUE, if string starts in sc-dictionary node; otherwise return SC_FALSE.
  */
 sc_bool sc_dictionary_is_in(sc_dictionary * dictionary, const sc_char * sc_string);
-
-/*! Gets a terminal sc-dictionary node where string ends.
- * @param dictionary A sc-dictionary pointer
- * @param node A sc-dictionary node where common prefix may be started
- * @param sc_string A string to retrieve data by it
- * @returns Returns A sc-dictionary node where string ends
- */
-sc_dictionary_node * sc_dictionary_get_last_node_from_node(
-    sc_dictionary * dictionary,
-    sc_dictionary_node * node,
-    const sc_char * sc_string);
 
 /*! Gets first data from a terminal sc-dictionary node where string ends.
  * @param dictionary A sc-dictionary pointer
@@ -159,46 +109,10 @@ void * sc_dictionary_get_first_data_from_node(
 
 /*! Gets datas from a terminal sc-dictionary node where string ends.
  * @param dictionary A sc-dictionary pointer
- * @param node A sc-dictionary node where common prefix may be started
- * @param sc_string A string to retrieve datas by it
- * @returns Returns Datas from a sc-dictionary node where string ends
- */
-sc_list * sc_dictionary_get_datas_from_node(
-    sc_dictionary * dictionary,
-    sc_dictionary_node * node,
-    const sc_char * sc_string);
-
-/*! Gets datas from a terminal sc-dictionary node where string ends.
- * @param dictionary A sc-dictionary pointer
  * @param sc_string A string to retrieve datas by it
  * @returns Returns Datas from a sc-dictionary node where string ends
  */
 sc_list * sc_dictionary_get(sc_dictionary * dictionary, const sc_char * sc_string);
-
-/*! Visits all sc-dictionary nodes starting with specified node and shows a terminal node datas with routes.
- * @param dictionary A sc-dictionary pointer
- * @param node A sc-dictionary node to start visiting
- * @param sc_string A tabulation for print procedure
- */
-void sc_dictionary_show_from_node(sc_dictionary * dictionary, sc_dictionary_node * node, sc_char * tab);
-
-/*! Visits all sc-dictionary nodes and shows a terminal node datas with routes.
- * @param dictionary A sc-dictionary to start visiting
- */
-void sc_dictionary_show(sc_dictionary * dictionary);
-
-/*! Visits all sc-dictionary nodes starting with specified node and calls procedure with it and its data. A method
- * completes down iterating visiting.
- * @param dictionary A sc-dictionary pointer
- * @param node A sc-dictionary node to start visiting
- * @param callable A callable object (procedure)
- * @param[out] dest A pointer to procedure result pointer
- */
-void sc_dictionary_visit_down_node_from_node(
-    sc_dictionary * dictionary,
-    sc_dictionary_node * node,
-    void (*callable)(sc_dictionary_node *, void **),
-    void ** dest);
 
 /*! Visits all sc-dictionary nodes and calls procedure with it and its data. A method completes down iterating visiting.
  * @param dictionary A sc-dictionary pointer
@@ -207,19 +121,6 @@ void sc_dictionary_visit_down_node_from_node(
  */
 void sc_dictionary_visit_down_nodes(
     sc_dictionary * dictionary,
-    void (*callable)(sc_dictionary_node *, void **),
-    void ** dest);
-
-/*! Visits all sc-dictionary nodes starting with specified node and calls procedure with it and its data. A method
- * completes up iterating visiting.
- * @param dictionary A sc-dictionary pointer
- * @param node A sc-dictionary node to start visiting
- * @param callable A callable object (procedure)
- * @param[out] dest A pointer to procedure result pointer
- */
-void sc_dictionary_visit_up_node_from_node(
-    sc_dictionary * dictionary,
-    sc_dictionary_node * node,
     void (*callable)(sc_dictionary_node *, void **),
     void ** dest);
 

--- a/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.h
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.h
@@ -38,13 +38,22 @@ typedef struct _sc_dictionary
 {
   sc_dictionary_node * root;  // sc-dictionary tree root node
   sc_uint8 size;              // default sc-dictionary node children size
+  void (*char_to_int)(sc_char, sc_uint8 *, sc_uint8 *);
+  void (*int_to_char)(sc_uint8, sc_uint8, sc_char *);
 } sc_dictionary;
 
 /*! Initializes sc-dictionary
- * @param dictionary Pointer to a sc-dictionary pointer to initialize
- * @returns[out] Returns SC_TRUE, if sc-dictionary didn't exist; otherwise return SC_FALSE.
+ * @param[out] dictionary Pointer to a sc-dictionary pointer to initialize
+ * @param[in] children_size SC-dictionary node children count
+ * @param[in] char_to_int Pointer to function that converts sc_char to sc_uint8 and returns sc_uint8 mask
+ * @param[in] int_to_char Pointer to function that converts sc_uint8 with sc_uint8 mask to sc_char
+ * @returns Returns SC_TRUE, if sc-dictionary didn't exist; otherwise return SC_FALSE.
  */
-sc_bool sc_dictionary_initialize(sc_dictionary ** dictionary);
+sc_bool sc_dictionary_initialize(
+    sc_dictionary ** dictionary,
+    sc_uint8 children_size,
+    void (*char_to_int)(sc_char, sc_uint8 *, sc_uint8 *),
+    void (*int_to_char)(sc_uint8, sc_uint8, sc_char *));
 
 /*! Destroys a sc-dictionary
  * @param dictionary A sc-dictionary pointer to destroy
@@ -61,16 +70,16 @@ void sc_dictionary_node_destroy(sc_dictionary_node * node, void ** args);
 
 /*! Appends a string to a sc-dictionary by a common prefix with another string started in sc-dictionary node, if such
  * exists.
- * @param node A sc-dictionary node where common prefix may be started
+ * @param dictionary A sc-dictionary pointer
  * @param sc_string An appendable string
  * @param size An appendable string size
  * @returns Returns A sc-dictionary node where appended string is ended
  */
-sc_dictionary_node * sc_dictionary_append_to_node(sc_dictionary_node * node, sc_char * sc_string, sc_uint32 size);
+sc_dictionary_node * sc_dictionary_append_to_node(sc_dictionary * dictionary, sc_char * sc_string, sc_uint32 size);
 
 /*! Appends a string to a sc-dictionary by a common prefix with another string started in sc-dictionary node, if such
  * exists. In end sc-dictionary node stores pointer to data by string.
- * @param node A sc-dictionary node where common prefix may be started
+ * @param dictionary A sc-dictionary pointer where common prefix may be started
  * @param sc_string An appendable string
  * @param size An appendable string size
  * @param data A pointer to data storing by appended string
@@ -80,6 +89,7 @@ sc_dictionary_node * sc_dictionary_append(sc_dictionary * dictionary, sc_char * 
 
 /*! Removes a string from a sc-dictionary by a common prefix with another string started in sc-dictionary node, if such
  * exists. A common prefix doesn't remove form sc-dictionary if it contains in another string.
+ * @param dictionary A sc-dictionary pointer
  * @param node A sc-dictionary node where common prefix may be started
  * @param sc_string A removable string
  * @param size Removable string size
@@ -87,6 +97,7 @@ sc_dictionary_node * sc_dictionary_append(sc_dictionary * dictionary, sc_char * 
  * @note If string isn't in sc-dictionary then null_pointer will be returned
  */
 sc_dictionary_node * sc_dictionary_remove_from_node(
+    sc_dictionary * dictionary,
     sc_dictionary_node * node,
     sc_uint8 node_index,
     sc_dictionary_node * parent,
@@ -105,60 +116,61 @@ sc_bool sc_dictionary_remove(sc_dictionary * dictionary, const sc_char * sc_stri
 
 /*! Checks, if a string starts in a sc-dictionary node by a common prefix with another string started in sc-dictionary
  * node, if such exists.
+ * @param dictionary A sc-dictionary pointer
  * @param node A sc-dictionary node where common prefix may be started
  * @param sc_string A verifiable string
  * @returns Returns SC_TRUE, if string starts in sc-dictionary node; otherwise return SC_FALSE.
  */
-sc_bool sc_dictionary_is_in_from_node(sc_dictionary_node * node, const sc_char * sc_string);
+sc_bool sc_dictionary_is_in_from_node(sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string);
 
 /*! Checks, if a string is in a sc-dictionary by a common prefix with another string started in sc-dictionary
  * node, if such exists.
- * @param sc_dictionary A sc-dictionary node where common prefix may be started
+ * @param dictionary A sc-dictionary pointer
  * @param sc_string A verifiable string
  * @returns Returns SC_TRUE, if string starts in sc-dictionary node; otherwise return SC_FALSE.
  */
 sc_bool sc_dictionary_is_in(sc_dictionary * dictionary, const sc_char * sc_string);
 
 /*! Gets a terminal sc-dictionary node where string ends.
+ * @param dictionary A sc-dictionary pointer
  * @param node A sc-dictionary node where common prefix may be started
  * @param sc_string A string to retrieve data by it
  * @returns Returns A sc-dictionary node where string ends
  */
-sc_dictionary_node * sc_dictionary_get_last_node_from_node(sc_dictionary_node * node, const sc_char * sc_string);
+sc_dictionary_node * sc_dictionary_get_last_node_from_node(
+    sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string);
 
 /*! Gets first data from a terminal sc-dictionary node where string ends.
+ * @param dictionary A sc-dictionary pointer
  * @param node A sc-dictionary node where common prefix may be started
  * @param sc_string A string to retrieve data by it
  * @returns Returns Data from a sc-dictionary node where string ends
  */
-void * sc_dictionary_get_first_data_from_node(sc_dictionary_node * node, const sc_char * sc_string);
+void * sc_dictionary_get_first_data_from_node(
+    sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string);
 
 /*! Gets datas from a terminal sc-dictionary node where string ends.
+ * @param dictionary A sc-dictionary pointer
  * @param node A sc-dictionary node where common prefix may be started
  * @param sc_string A string to retrieve datas by it
  * @returns Returns Datas from a sc-dictionary node where string ends
  */
-sc_list * sc_dictionary_get_datas_from_node(sc_dictionary_node * node, const sc_char * sc_string);
+sc_list * sc_dictionary_get_datas_from_node(
+    sc_dictionary * dictionary, sc_dictionary_node * node, const sc_char * sc_string);
 
 /*! Gets datas from a terminal sc-dictionary node where string ends.
- * @param dictionary A sc-dictionary
+ * @param dictionary A sc-dictionary pointer
  * @param sc_string A string to retrieve datas by it
  * @returns Returns Datas from a sc-dictionary node where string ends
  */
 sc_list * sc_dictionary_get(sc_dictionary * dictionary, const sc_char * sc_string);
 
-/*! Gets datas from a sc-dictionary nodes where substring ends.
- * @param dictionary A sc-dictionary
- * @param sc_substr A substring to retrieve datas by it
- * @returns Returns Datas from a sc-dictionary node where string ends
- */
-sc_list * sc_dictionary_get_by_substr(sc_dictionary * dictionary, const sc_char * sc_substr);
-
 /*! Visits all sc-dictionary nodes starting with specified node and shows a terminal node datas with routes.
+ * @param dictionary A sc-dictionary pointer
  * @param node A sc-dictionary node to start visiting
  * @param sc_string A tabulation for print procedure
  */
-void sc_dictionary_show_from_node(sc_dictionary_node * node, sc_char * tab);
+void sc_dictionary_show_from_node(sc_dictionary * dictionary, sc_dictionary_node * node, sc_char * tab);
 
 /*! Visits all sc-dictionary nodes and shows a terminal node datas with routes.
  * @param dictionary A sc-dictionary to start visiting
@@ -167,17 +179,19 @@ void sc_dictionary_show(sc_dictionary * dictionary);
 
 /*! Visits all sc-dictionary nodes starting with specified node and calls procedure with it and its data. A method
  * completes down iterating visiting.
+ * @param dictionary A sc-dictionary pointer
  * @param node A sc-dictionary node to start visiting
  * @param callable A callable object (procedure)
  * @param[out] dest A pointer to procedure result pointer
  */
 void sc_dictionary_visit_down_node_from_node(
+    sc_dictionary * dictionary,
     sc_dictionary_node * node,
     void (*callable)(sc_dictionary_node *, void **),
     void ** dest);
 
 /*! Visits all sc-dictionary nodes and calls procedure with it and its data. A method completes down iterating visiting.
- * @param node A sc-dictionary
+ * @param dictionary A sc-dictionary pointer
  * @param callable A callable object (procedure)
  * @param[out] dest A pointer to procedure result pointer
  */
@@ -188,11 +202,13 @@ void sc_dictionary_visit_down_nodes(
 
 /*! Visits all sc-dictionary nodes starting with specified node and calls procedure with it and its data. A method
  * completes up iterating visiting.
+ * @param dictionary A sc-dictionary pointer
  * @param node A sc-dictionary node to start visiting
  * @param callable A callable object (procedure)
  * @param[out] dest A pointer to procedure result pointer
  */
 void sc_dictionary_visit_up_node_from_node(
+    sc_dictionary * dictionary,
     sc_dictionary_node * node,
     void (*callable)(sc_dictionary_node *, void **),
     void ** dest);

--- a/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.h
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.h
@@ -75,7 +75,10 @@ void sc_dictionary_node_destroy(sc_dictionary_node * node, void ** args);
  * @param size An appendable string size
  * @returns Returns A sc-dictionary node where appended string is ended
  */
-sc_dictionary_node * sc_dictionary_append_to_node(sc_dictionary * dictionary, sc_char * sc_string, sc_uint32 size);
+sc_dictionary_node * sc_dictionary_append_to_node(
+    sc_dictionary * dictionary,
+    const sc_char * sc_string,
+    sc_uint32 size);
 
 /*! Appends a string to a sc-dictionary by a common prefix with another string started in sc-dictionary node, if such
  * exists. In end sc-dictionary node stores pointer to data by string.
@@ -85,7 +88,11 @@ sc_dictionary_node * sc_dictionary_append_to_node(sc_dictionary * dictionary, sc
  * @param data A pointer to data storing by appended string
  * @returns Returns A sc-dictionary node where appended string ends
  */
-sc_dictionary_node * sc_dictionary_append(sc_dictionary * dictionary, sc_char * sc_string, sc_uint32 size, void * data);
+sc_dictionary_node * sc_dictionary_append(
+    sc_dictionary * dictionary,
+    const sc_char * sc_string,
+    sc_uint32 size,
+    void * data);
 
 /*! Removes a string from a sc-dictionary by a common prefix with another string started in sc-dictionary node, if such
  * exists. A common prefix doesn't remove form sc-dictionary if it contains in another string.
@@ -99,11 +106,8 @@ sc_dictionary_node * sc_dictionary_append(sc_dictionary * dictionary, sc_char * 
 sc_dictionary_node * sc_dictionary_remove_from_node(
     sc_dictionary * dictionary,
     sc_dictionary_node * node,
-    sc_uint8 node_index,
-    sc_dictionary_node * parent,
     const sc_char * sc_string,
-    sc_uint32 index,
-    sc_uint8 * removable_index);
+    sc_uint32 index);
 
 /*! Removes a string from a sc-dictionary by a common prefix with another string started in sc-dictionary node, if such
  * exists. A common prefix doesn't remove form sc-dictionary if it contains in another string.

--- a/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary_private.h
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary_private.h
@@ -10,18 +10,12 @@
 #include "../../sc_types.h"
 #include "../sc-list/sc_list.h"
 
-sc_uint8 _sc_dictionary_children_size();
+sc_dictionary_node * _sc_dictionary_node_initialize(sc_uint8 children_size);
 
-sc_dictionary_node * _sc_dictionary_node_initialize();
-
-sc_dictionary_node * _sc_dictionary_get_next_node(sc_dictionary_node * node, sc_char ch);
+sc_dictionary_node * _sc_dictionary_get_next_node(sc_dictionary * dictionary, sc_dictionary_node * node, sc_char ch);
 
 sc_addr * sc_list_to_addr_array(sc_list * list);
 
 sc_addr_hash * sc_list_to_hashes_array(sc_list * list);
-
-void sc_char_to_sc_int(sc_char ch, sc_uint8 * ch_num, sc_uint8 * mask);
-
-sc_char sc_int_to_sc_char(sc_uint8 num, sc_uint8 mask);
 
 #endif

--- a/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary_private.h
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary_private.h
@@ -18,4 +18,68 @@ sc_addr * sc_list_to_addr_array(sc_list * list);
 
 sc_addr_hash * sc_list_to_hashes_array(sc_list * list);
 
+/*! Appends a string to a sc-dictionary by a common prefix with another string started in sc-dictionary node, if such
+ * exists.
+ * @param dictionary A sc-dictionary pointer
+ * @param sc_string An appendable string
+ * @param size An appendable string size
+ * @returns Returns A sc-dictionary node where appended string is ended
+ */
+sc_dictionary_node * sc_dictionary_append_to_node(
+    sc_dictionary * dictionary,
+    const sc_char * sc_string,
+    sc_uint32 size);
+
+/*! Removes a string from a sc-dictionary by a common prefix with another string started in sc-dictionary node, if such
+ * exists. A common prefix doesn't remove form sc-dictionary if it contains in another string.
+ * @param dictionary A sc-dictionary pointer
+ * @param node A sc-dictionary node where common prefix may be started
+ * @param sc_string A removable string
+ * @param size Removable string size
+ * @returns Returns A sc-dictionary node where removable string or its prefix starts
+ * @note If string isn't in sc-dictionary then null_pointer will be returned
+ */
+sc_dictionary_node * sc_dictionary_remove_from_node(
+    sc_dictionary * dictionary,
+    sc_dictionary_node * node,
+    const sc_char * sc_string,
+    sc_uint32 index);
+
+/*! Gets a terminal sc-dictionary node where string ends.
+ * @param dictionary A sc-dictionary pointer
+ * @param node A sc-dictionary node where common prefix may be started
+ * @param sc_string A string to retrieve data by it
+ * @returns Returns A sc-dictionary node where string ends
+ */
+sc_dictionary_node * sc_dictionary_get_last_node_from_node(
+    sc_dictionary * dictionary,
+    sc_dictionary_node * node,
+    const sc_char * sc_string);
+
+/*! Visits all sc-dictionary nodes starting with specified node and calls procedure with it and its data. A method
+ * completes down iterating visiting.
+ * @param dictionary A sc-dictionary pointer
+ * @param node A sc-dictionary node to start visiting
+ * @param callable A callable object (procedure)
+ * @param[out] dest A pointer to procedure result pointer
+ */
+void sc_dictionary_visit_down_node_from_node(
+    sc_dictionary * dictionary,
+    sc_dictionary_node * node,
+    void (*callable)(sc_dictionary_node *, void **),
+    void ** dest);
+
+/*! Visits all sc-dictionary nodes starting with specified node and calls procedure with it and its data. A method
+ * completes up iterating visiting.
+ * @param dictionary A sc-dictionary pointer
+ * @param node A sc-dictionary node to start visiting
+ * @param callable A callable object (procedure)
+ * @param[out] dest A pointer to procedure result pointer
+ */
+void sc_dictionary_visit_up_node_from_node(
+    sc_dictionary * dictionary,
+    sc_dictionary_node * node,
+    void (*callable)(sc_dictionary_node *, void **),
+    void ** dest);
+
 #endif

--- a/sc-memory/sc-core/sc-store/sc-container/sc-list/sc_list.c
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-list/sc_list.c
@@ -36,6 +36,10 @@ sc_bool sc_list_destroy(sc_list * list)
     sc_mem_free(temp);
   }
 
+  list->begin = null_ptr;
+  list->end = null_ptr;
+  list->size = 0;
+
   sc_mem_free(list);
 
   return SC_TRUE;

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.c
@@ -393,6 +393,14 @@ void sc_dictionary_fs_storage_get_sc_string_ext(
   *size = len;
 }
 
+sc_bool sc_dictionary_fs_storage_remove_sc_string(sc_element * element, sc_addr addr)
+{
+  sc_char * hash_str = sc_addr_to_str(addr);
+  sc_bool result = sc_dictionary_remove(strings_dictionary, hash_str);
+  sc_mem_free(hash_str);
+  return result;
+}
+
 void sc_fs_storage_write_nodes(void (*callable)(sc_dictionary_node *, void **), GIOChannel * strings_dest)
 {
   GIOChannel ** dest = sc_mem_new(GIOChannel *, 2);

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.c
@@ -12,6 +12,7 @@
 
 #  include "../sc-base/sc_message.h"
 #  include "../sc-container/sc-string/sc_string.h"
+#  include "../sc-container/sc-dictionary/sc_dictionary_private.h"
 
 #  include <glib/gstdio.h>
 
@@ -29,18 +30,12 @@ sc_bool sc_dictionary_fs_storage_initialize(const sc_char * path)
 
   sc_message("Initialize sc-dictionary fs-storage from path: %s", path);
   sc_bool result = sc_dictionary_initialize(
-      &addrs_hashes_dictionary,
-      _sc_dictionary_addr_hashes_children_size(),
-      _sc_dictionary_addr_hashes_char_to_int,
-      _sc_dictionary_addr_hashes_int_to_char);
+      &addrs_hashes_dictionary, _sc_dictionary_addr_hashes_children_size(), _sc_dictionary_addr_hashes_char_to_int);
   if (result == SC_FALSE)
     return SC_FALSE;
 
   result = sc_dictionary_initialize(
-      &strings_dictionary,
-      _sc_dictionary_strings_children_size(),
-      _sc_dictionary_strings_char_to_int,
-      _sc_dictionary_strings_int_to_char);
+      &strings_dictionary, _sc_dictionary_strings_children_size(), _sc_dictionary_strings_char_to_int);
   if (result == SC_FALSE)
     return SC_FALSE;
 

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.c
@@ -243,6 +243,7 @@ sc_bool sc_dictionary_fs_storage_get_sc_links_by_substr(const sc_char * sc_subst
 
   *links = sc_list_to_addr_array(list);
   *size = list->size;
+  sc_list_destroy(list);
 
   return SC_TRUE;
 }
@@ -274,7 +275,8 @@ sc_char ** sc_list_to_strings_array(sc_list * list)
   sc_iterator * it = sc_list_iterator(list);
   while (sc_iterator_next(it))
   {
-    **temp = sc_iterator_get(it);
+    sc_char * str = sc_iterator_get(it);
+    sc_str_cpy(**temp, str, strlen(str));
     ++*temp;
   }
   sc_mem_free(temp);
@@ -306,6 +308,7 @@ sc_bool sc_dictionary_fs_storage_get_sc_strings_by_substr(
 
   *strings = sc_list_to_strings_array(list);
   *size = list->size;
+  sc_list_destroy(list);
 
   return SC_TRUE;
 }

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.c
@@ -122,7 +122,7 @@ sc_dictionary_node * _sc_dictionary_fs_storage_append_sc_link_unique(sc_char * s
 {
   sc_addr_hash other = sc_addr_to_hash(addr);
 
-  sc_link_content * old_content = sc_dictionary_fs_storage_get_link_content(addr);
+  sc_link_content * old_content = sc_dictionary_fs_storage_get_sc_link_content(addr);
   if (old_content != null_ptr && old_content->sc_string != null_ptr && old_content->node != null_ptr)
   {
     if (strcmp(old_content->sc_string, sc_string) == 0)
@@ -135,7 +135,11 @@ sc_dictionary_node * _sc_dictionary_fs_storage_append_sc_link_unique(sc_char * s
   return sc_dictionary_append(addrs_hashes_dictionary, sc_string, size, &other);
 }
 
-sc_bool sc_dictionary_fs_storage_append_sc_link(sc_element * element, sc_addr addr, sc_char * sc_string, sc_uint32 size)
+sc_bool sc_dictionary_fs_storage_append_sc_link_content(
+    sc_element * element,
+    sc_addr addr,
+    sc_char * sc_string,
+    sc_uint32 size)
 {
   sc_dictionary_node * node = _sc_dictionary_fs_storage_append_sc_link_unique(sc_string, size, addr);
   _sc_dictionary_fs_storage_append_sc_string_sc_link_reference(addr, node, sc_string, size);
@@ -184,7 +188,7 @@ sc_addr_hash * sc_list_to_hashes_array(sc_list * list)
   return hashes;
 }
 
-sc_bool sc_dictionary_fs_storage_get_sc_links(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size)
+sc_bool sc_dictionary_fs_storage_get_sc_links_by_content(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size)
 {
   sc_list * list = sc_dictionary_get(addrs_hashes_dictionary, sc_string);
 
@@ -223,7 +227,10 @@ void _sc_dictionary_fs_storage_update_links_list(sc_dictionary_node * node, void
   }
 }
 
-sc_bool sc_dictionary_fs_storage_get_sc_links_by_substr(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size)
+sc_bool sc_dictionary_fs_storage_get_sc_links_by_content_substr(
+    const sc_char * sc_substr,
+    sc_addr ** links,
+    sc_uint32 * size)
 {
   sc_list * list;
   sc_list_init(&list);
@@ -285,7 +292,7 @@ sc_char ** sc_list_to_strings_array(sc_list * list)
   return strings;
 }
 
-sc_bool sc_dictionary_fs_storage_get_sc_strings_by_substr(
+sc_bool sc_dictionary_fs_storage_get_sc_links_contents_by_content_substr(
     const sc_char * sc_substr,
     sc_char *** strings,
     sc_uint32 * size)
@@ -313,41 +320,7 @@ sc_bool sc_dictionary_fs_storage_get_sc_strings_by_substr(
   return SC_TRUE;
 }
 
-sc_char * sc_dictionary_fs_storage_get_sc_string(sc_addr addr)
-{
-  if (SC_ADDR_IS_EMPTY(addr))
-    return null_ptr;
-
-  sc_char * hash = sc_addr_to_str(addr);
-  sc_link_content * content =
-      sc_dictionary_get_first_data_from_node(strings_dictionary, strings_dictionary->root, hash);
-  sc_mem_free(hash);
-
-  if (content == null_ptr || content->sc_string == null_ptr)
-    return null_ptr;
-
-  sc_uint32 len = content->string_size;
-  sc_char * copy = sc_mem_new(sc_char, len + 1);
-  return sc_mem_cpy(copy, content->sc_string, len);
-}
-
-sc_dictionary_node * sc_dictionary_fs_storage_get_node(sc_addr addr)
-{
-  if (SC_ADDR_IS_EMPTY(addr))
-    return null_ptr;
-
-  sc_char * hash = sc_addr_to_str(addr);
-  sc_link_content * content =
-      sc_dictionary_get_first_data_from_node(strings_dictionary, strings_dictionary->root, hash);
-  sc_mem_free(hash);
-
-  if (content == null_ptr || content->node == null_ptr)
-    return null_ptr;
-
-  return content->node;
-}
-
-sc_link_content * sc_dictionary_fs_storage_get_link_content(sc_addr addr)
+sc_link_content * sc_dictionary_fs_storage_get_sc_link_content(sc_addr addr)
 {
   if (SC_ADDR_IS_EMPTY(addr))
     return null_ptr;
@@ -363,7 +336,7 @@ sc_link_content * sc_dictionary_fs_storage_get_link_content(sc_addr addr)
   return content;
 }
 
-void sc_dictionary_fs_storage_get_sc_string_ext(
+void sc_dictionary_fs_storage_get_sc_link_content_ext(
     sc_element * element,
     sc_addr addr,
     sc_char ** sc_string,
@@ -393,7 +366,7 @@ void sc_dictionary_fs_storage_get_sc_string_ext(
   *size = len;
 }
 
-sc_bool sc_dictionary_fs_storage_remove_sc_string(sc_element * element, sc_addr addr)
+sc_bool sc_dictionary_fs_storage_remove_sc_link_content(sc_element * element, sc_addr addr)
 {
   sc_char * hash_str = sc_addr_to_str(addr);
   sc_bool result = sc_dictionary_remove(strings_dictionary, hash_str);
@@ -533,7 +506,7 @@ sc_bool sc_dictionary_fs_storage_fill()
       addr.seg = SC_ADDR_LOCAL_SEG_FROM_INT(hashes[i]);
       addr.offset = SC_ADDR_LOCAL_OFFSET_FROM_INT(hashes[i]);
 
-      sc_dictionary_fs_storage_append_sc_link(null_ptr, addr, string, string_size);
+      sc_dictionary_fs_storage_append_sc_link_content(null_ptr, addr, string, string_size);
     }
 
     sc_mem_free(hashes);

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.c
@@ -283,7 +283,10 @@ sc_char ** sc_list_to_strings_array(sc_list * list)
   return strings;
 }
 
-sc_bool sc_dictionary_fs_storage_get_sc_strings_by_substr(const sc_char * sc_substr, sc_char *** strings, sc_uint32 * size)
+sc_bool sc_dictionary_fs_storage_get_sc_strings_by_substr(
+    const sc_char * sc_substr,
+    sc_char *** strings,
+    sc_uint32 * size)
 {
   sc_list * list;
   sc_list_init(&list);
@@ -313,8 +316,8 @@ sc_char * sc_dictionary_fs_storage_get_sc_string(sc_addr addr)
     return null_ptr;
 
   sc_char * hash = sc_addr_to_str(addr);
-  sc_link_content * content = sc_dictionary_get_first_data_from_node(
-      strings_dictionary, strings_dictionary->root, hash);
+  sc_link_content * content =
+      sc_dictionary_get_first_data_from_node(strings_dictionary, strings_dictionary->root, hash);
   sc_mem_free(hash);
 
   if (content == null_ptr || content->sc_string == null_ptr)
@@ -331,8 +334,8 @@ sc_dictionary_node * sc_dictionary_fs_storage_get_node(sc_addr addr)
     return null_ptr;
 
   sc_char * hash = sc_addr_to_str(addr);
-  sc_link_content * content = sc_dictionary_get_first_data_from_node(
-      strings_dictionary, strings_dictionary->root, hash);
+  sc_link_content * content =
+      sc_dictionary_get_first_data_from_node(strings_dictionary, strings_dictionary->root, hash);
   sc_mem_free(hash);
 
   if (content == null_ptr || content->node == null_ptr)
@@ -347,8 +350,8 @@ sc_link_content * sc_dictionary_fs_storage_get_link_content(sc_addr addr)
     return null_ptr;
 
   sc_char * hash = sc_addr_to_str(addr);
-  sc_link_content * content = sc_dictionary_get_first_data_from_node(
-      strings_dictionary, strings_dictionary->root, hash);
+  sc_link_content * content =
+      sc_dictionary_get_first_data_from_node(strings_dictionary, strings_dictionary->root, hash);
   sc_mem_free(hash);
 
   if (content == null_ptr || content->node == null_ptr || content->sc_string == null_ptr)
@@ -371,8 +374,8 @@ void sc_dictionary_fs_storage_get_sc_string_ext(
   }
 
   sc_char * hash = sc_addr_to_str(addr);
-  sc_link_content * content = sc_dictionary_get_first_data_from_node(
-      strings_dictionary, strings_dictionary->root, hash);
+  sc_link_content * content =
+      sc_dictionary_get_first_data_from_node(strings_dictionary, strings_dictionary->root, hash);
   sc_mem_free(hash);
   if (content == null_ptr)
   {

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.h
@@ -63,6 +63,14 @@ sc_bool sc_dictionary_fs_storage_get_sc_links(const sc_char * sc_string, sc_addr
  */
 sc_bool sc_dictionary_fs_storage_get_sc_links_by_substr(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size);
 
+/*! Gets sc-strings from sc-dictionary by it substring content.
+ * @param sc_substr A key substring
+ * @param[out] strings A pointer to sc-strings array
+ * @param[out] size A sc-strings size
+ * @returns SC_TRUE, if sc-links exist.
+ */
+sc_bool sc_dictionary_fs_storage_get_sc_strings_by_substr(const sc_char * sc_substr, sc_char *** strings, sc_uint32 * size);
+
 /*! Gets sc-link content.
  * @param addr A sc-link with content
  * @returns A sc-link-content node.

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.h
@@ -41,7 +41,7 @@ sc_bool sc_dictionary_fs_storage_fill();
  * @param size A key string size
  * @returns SC_TRUE, if link was added
  */
-sc_bool sc_dictionary_fs_storage_append_sc_link(
+sc_bool sc_dictionary_fs_storage_append_sc_link_content(
     sc_element * element,
     sc_addr addr,
     sc_char * sc_string,
@@ -53,7 +53,7 @@ sc_bool sc_dictionary_fs_storage_append_sc_link(
  * @param[out] size A sc-links size
  * @returns SC_TRUE, if sc-links exist.
  */
-sc_bool sc_dictionary_fs_storage_get_sc_links(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size);
+sc_bool sc_dictionary_fs_storage_get_sc_links_by_content(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size);
 
 /*! Gets sc-links from sc-dictionary by it substring content.
  * @param sc_substr A key substring
@@ -61,7 +61,10 @@ sc_bool sc_dictionary_fs_storage_get_sc_links(const sc_char * sc_string, sc_addr
  * @param[out] size A sc-links size
  * @returns SC_TRUE, if sc-links exist.
  */
-sc_bool sc_dictionary_fs_storage_get_sc_links_by_substr(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size);
+sc_bool sc_dictionary_fs_storage_get_sc_links_by_content_substr(
+    const sc_char * sc_substr,
+    sc_addr ** links,
+    sc_uint32 * size);
 
 /*! Gets sc-strings from sc-dictionary by it substring content.
  * @param sc_substr A key substring
@@ -69,7 +72,7 @@ sc_bool sc_dictionary_fs_storage_get_sc_links_by_substr(const sc_char * sc_subst
  * @param[out] size A sc-strings size
  * @returns SC_TRUE, if sc-links exist.
  */
-sc_bool sc_dictionary_fs_storage_get_sc_strings_by_substr(
+sc_bool sc_dictionary_fs_storage_get_sc_links_contents_by_content_substr(
     const sc_char * sc_substr,
     sc_char *** strings,
     sc_uint32 * size);
@@ -78,7 +81,7 @@ sc_bool sc_dictionary_fs_storage_get_sc_strings_by_substr(
  * @param addr A sc-link with content
  * @returns A sc-link-content node.
  */
-sc_link_content * sc_dictionary_fs_storage_get_link_content(sc_addr addr);
+sc_link_content * sc_dictionary_fs_storage_get_sc_link_content(sc_addr addr);
 
 /*! Gets sc-link content string with its size.
  * @param element A sc-link
@@ -86,24 +89,18 @@ sc_link_content * sc_dictionary_fs_storage_get_link_content(sc_addr addr);
  * @param[out] sc_string A content string
  * @param[out] size A content string size
  */
-void sc_dictionary_fs_storage_get_sc_string_ext(
+void sc_dictionary_fs_storage_get_sc_link_content_ext(
     sc_element * element,
     sc_addr addr,
     sc_char ** sc_string,
     sc_uint32 * size);
-
-/*! Gets sc-link content string.
- * @param addr A sc-link
- * @returns A content string.
- */
-sc_char * sc_dictionary_fs_storage_get_sc_string(sc_addr addr);
 
 /*! Removes sc-link content string from sc-dictionary.
  * @param element A sc-link element
  * @param addr A sc-link addr
  * @returns SC_TRUE, if such sc-link exists in sc-dictionary.
  */
-sc_bool sc_dictionary_fs_storage_remove_sc_string(sc_element * element, sc_addr addr);
+sc_bool sc_dictionary_fs_storage_remove_sc_link_content(sc_element * element, sc_addr addr);
 
 sc_uint32 sc_addr_to_hash(sc_addr addr);
 

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.h
@@ -81,7 +81,7 @@ sc_bool sc_dictionary_fs_storage_get_sc_strings_by_substr(
 sc_link_content * sc_dictionary_fs_storage_get_link_content(sc_addr addr);
 
 /*! Gets sc-link content string with its size.
- * @param addr A sc-link
+ * @param element A sc-link
  * @param addr A sc-link addr
  * @param[out] sc_string A content string
  * @param[out] size A content string size
@@ -97,6 +97,13 @@ void sc_dictionary_fs_storage_get_sc_string_ext(
  * @returns A content string.
  */
 sc_char * sc_dictionary_fs_storage_get_sc_string(sc_addr addr);
+
+/*! Removes sc-link content string from sc-dictionary.
+ * @param element A sc-link element
+ * @param addr A sc-link addr
+ * @returns SC_TRUE, if such sc-link exists in sc-dictionary.
+ */
+sc_bool sc_dictionary_fs_storage_remove_sc_string(sc_element * element, sc_addr addr);
 
 sc_uint32 sc_addr_to_hash(sc_addr addr);
 

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage.h
@@ -69,7 +69,10 @@ sc_bool sc_dictionary_fs_storage_get_sc_links_by_substr(const sc_char * sc_subst
  * @param[out] size A sc-strings size
  * @returns SC_TRUE, if sc-links exist.
  */
-sc_bool sc_dictionary_fs_storage_get_sc_strings_by_substr(const sc_char * sc_substr, sc_char *** strings, sc_uint32 * size);
+sc_bool sc_dictionary_fs_storage_get_sc_strings_by_substr(
+    const sc_char * sc_substr,
+    sc_char *** strings,
+    sc_uint32 * size);
 
 /*! Gets sc-link content.
  * @param addr A sc-link with content

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage_private.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage_private.h
@@ -1,0 +1,87 @@
+/*
+ * This source file is part of an OSTIS project. For the latest info, see http://ostis.net
+ * Distributed under the MIT License
+ * (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
+ */
+
+#ifndef _sc_dictionary_fs_storage_private_h_
+#define _sc_dictionary_fs_storage_private_h_
+
+#include "../sc_types.h"
+#include "../sc-base/sc_allocator.h"
+
+#include "stdio.h"
+
+inline sc_uint32 sc_addr_to_hash(sc_addr addr)
+{
+  return SC_ADDR_LOCAL_TO_INT(addr);
+}
+
+sc_char * itora(sc_uint32 num)
+{
+  sc_uint32 copy_num = num;
+
+  sc_uint32 size = 0;
+  while (copy_num > 0)
+  {
+    copy_num /= 10;
+    ++size;
+  }
+
+  sc_char * result = sc_mem_new(sc_char, size + 1);
+  sc_char * index = result;
+
+  while (num > 0)
+  {
+    *index++ = (sc_char)((num % 10) | '0');
+    num /= 10;
+  }
+
+  return result;
+}
+
+inline sc_char * sc_addr_to_str(sc_addr addr)
+{
+  sc_uint32 hash = sc_addr_to_hash(addr);
+
+  // !reverse translation for more effectively work
+  return itora(hash);
+}
+
+sc_uint8 _sc_dictionary_addr_hashes_children_size()
+{
+  const sc_uint8 max_sc_char = 255;
+  const sc_uint8 min_sc_char = 1;
+
+  return max_sc_char - min_sc_char + 1;
+}
+
+void _sc_dictionary_addr_hashes_char_to_int(sc_char ch, sc_uint8 * ch_num, sc_uint8 * mask)
+{
+  *ch_num = 128 + (sc_uint8)ch;
+}
+
+void _sc_dictionary_addr_hashes_int_to_char(sc_uint8 num, sc_uint8 mask, sc_char * ch)
+{
+  *ch = (sc_char)(num - 128);
+}
+
+sc_uint8 _sc_dictionary_strings_children_size()
+{
+  const sc_uint8 max_sc_char = 10;
+  const sc_uint8 min_sc_char = 1;
+
+  return max_sc_char - min_sc_char + 1;
+}
+
+void _sc_dictionary_strings_char_to_int(sc_char ch, sc_uint8 * ch_num, sc_uint8 * mask)
+{
+  *ch_num = (sc_uint8)ch - 48;
+}
+
+void _sc_dictionary_strings_int_to_char(sc_uint8 num, sc_uint8 mask, sc_char * ch)
+{
+  *ch = (sc_char)(num + 48);
+}
+
+#endif

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage_private.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_dictionary_fs_storage_private.h
@@ -61,11 +61,6 @@ void _sc_dictionary_addr_hashes_char_to_int(sc_char ch, sc_uint8 * ch_num, sc_ui
   *ch_num = 128 + (sc_uint8)ch;
 }
 
-void _sc_dictionary_addr_hashes_int_to_char(sc_uint8 num, sc_uint8 mask, sc_char * ch)
-{
-  *ch = (sc_char)(num - 128);
-}
-
 sc_uint8 _sc_dictionary_strings_children_size()
 {
   const sc_uint8 max_sc_char = 10;
@@ -77,11 +72,6 @@ sc_uint8 _sc_dictionary_strings_children_size()
 void _sc_dictionary_strings_char_to_int(sc_char ch, sc_uint8 * ch_num, sc_uint8 * mask)
 {
   *ch_num = (sc_uint8)ch - 48;
-}
-
-void _sc_dictionary_strings_int_to_char(sc_uint8 num, sc_uint8 mask, sc_char * ch)
-{
-  *ch = (sc_char)(num + 48);
 }
 
 #endif

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage.c
@@ -90,6 +90,11 @@ sc_bool sc_fs_storage_get_sc_links_by_substr(const sc_char * sc_substr, sc_addr 
   return storage_instance->get_sc_links_by_substr(sc_substr, links, size);
 }
 
+sc_bool sc_fs_storage_get_sc_strings_by_substr(const sc_char * sc_substr, sc_char *** strings, sc_uint32 * size)
+{
+  return storage_instance->get_sc_strings_by_substr(sc_substr, strings, size);
+}
+
 void sc_fs_storage_get_sc_string_ext(sc_element * element, sc_addr addr, sc_char ** sc_string, sc_uint32 * size)
 {
   storage_instance->get_sc_string_ext(element, addr, &*sc_string, size);

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage.c
@@ -77,32 +77,35 @@ sc_bool sc_fs_storage_shutdown(sc_segment ** segments, sc_bool save_segments)
 
 sc_bool sc_fs_storage_append_sc_link(sc_element * element, sc_addr addr, sc_char * sc_string, sc_uint32 size)
 {
-  return storage_instance->append_sc_link(element, addr, sc_string, size);
+  return storage_instance->append_sc_link_content(element, addr, sc_string, size);
 }
 
-sc_bool sc_fs_storage_get_sc_links(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size)
+sc_bool sc_fs_storage_get_sc_links_by_content(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size)
 {
-  return storage_instance->get_sc_links(sc_string, links, size);
+  return storage_instance->get_sc_links_by_content(sc_string, links, size);
 }
 
-sc_bool sc_fs_storage_get_sc_links_by_substr(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size)
+sc_bool sc_fs_storage_get_sc_links_by_content_substr(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size)
 {
-  return storage_instance->get_sc_links_by_substr(sc_substr, links, size);
+  return storage_instance->get_sc_links_by_content_substring(sc_substr, links, size);
 }
 
-sc_bool sc_fs_storage_get_sc_strings_by_substr(const sc_char * sc_substr, sc_char *** strings, sc_uint32 * size)
+sc_bool sc_fs_storage_get_sc_links_contents_by_content_substr(
+    const sc_char * sc_substr,
+    sc_char *** strings,
+    sc_uint32 * size)
 {
-  return storage_instance->get_sc_strings_by_substr(sc_substr, strings, size);
+  return storage_instance->get_sc_links_contents_by_content_substring(sc_substr, strings, size);
 }
 
-void sc_fs_storage_get_sc_string_ext(sc_element * element, sc_addr addr, sc_char ** sc_string, sc_uint32 * size)
+void sc_fs_storage_get_sc_link_content_ext(sc_element * element, sc_addr addr, sc_char ** sc_string, sc_uint32 * size)
 {
-  storage_instance->get_sc_string_ext(element, addr, &*sc_string, size);
+  storage_instance->get_sc_link_content_ext(element, addr, &*sc_string, size);
 }
 
-sc_bool sc_fs_storage_remove_sc_string(sc_element * element, sc_addr addr)
+sc_bool sc_fs_storage_remove_sc_link_content(sc_element * element, sc_addr addr)
 {
-  return storage_instance->remove_sc_string(element, addr);
+  return storage_instance->remove_sc_link_content(element, addr);
 }
 
 // dictionary read, write and save methods

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage.c
@@ -100,6 +100,11 @@ void sc_fs_storage_get_sc_string_ext(sc_element * element, sc_addr addr, sc_char
   storage_instance->get_sc_string_ext(element, addr, &*sc_string, size);
 }
 
+sc_bool sc_fs_storage_remove_sc_string(sc_element * element, sc_addr addr)
+{
+  return storage_instance->remove_sc_string(element, addr);
+}
+
 // dictionary read, write and save methods
 sc_bool sc_fs_storage_read_from_path(sc_segment ** segments, sc_uint32 * segments_num)
 {

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage.h
@@ -23,6 +23,7 @@ typedef struct _sc_fs_storage
   sc_bool (*append_sc_link)(sc_element *, sc_addr, sc_char *, sc_uint32);
   sc_bool (*get_sc_links)(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size);
   sc_bool (*get_sc_links_by_substr)(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size);
+  sc_bool (*get_sc_strings_by_substr)(const sc_char * sc_substr, sc_char *** strings, sc_uint32 * size);
   void (*get_sc_string_ext)(sc_element * element, sc_addr addr, sc_char ** sc_string, sc_uint32 * size);
 } sc_fs_storage;
 
@@ -64,9 +65,17 @@ sc_bool sc_fs_storage_get_sc_links(const sc_char * sc_string, sc_addr ** links, 
  * @param sc_substr A key substring
  * @param[out] links A pointer to sc-links
  * @param[out] size A sc-links size
- * @returns SC_TRUE, if sc-links exist.
+ * @returns SC_TRUE, if such sc-links exist.
  */
 sc_bool sc_fs_storage_get_sc_links_by_substr(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size);
+
+/*! Gets sc-strings from file system storage by it substring content.
+ * @param sc_substr A key substring
+ * @param[out] links A pointer to sc-strings array
+ * @param[out] size A sc-strings array size
+ * @returns SC_TRUE, if such sc-strings exist.
+ */
+sc_bool sc_fs_storage_get_sc_strings_by_substr(const sc_char * sc_substr, sc_char *** strings, sc_uint32 * size);
 
 /*! Gets sc-link content string with its size.
  * @param addr A sc-link

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage.h
@@ -20,12 +20,13 @@ typedef struct _sc_fs_storage
   sc_bool (*clear)();
   sc_bool (*fill)();
   sc_bool (*save)();
-  sc_bool (*append_sc_link)(sc_element *, sc_addr, sc_char *, sc_uint32);
-  sc_bool (*get_sc_links)(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size);
-  sc_bool (*get_sc_links_by_substr)(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size);
-  sc_bool (*get_sc_strings_by_substr)(const sc_char * sc_substr, sc_char *** strings, sc_uint32 * size);
-  void (*get_sc_string_ext)(sc_element * element, sc_addr addr, sc_char ** sc_string, sc_uint32 * size);
-  sc_bool (*remove_sc_string)(sc_element * element, sc_addr addr);
+  sc_bool (*append_sc_link_content)(sc_element *, sc_addr, sc_char *, sc_uint32);
+  sc_bool (*get_sc_links_by_content)(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size);
+  sc_bool (*get_sc_links_by_content_substring)(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size);
+  sc_bool (
+      *get_sc_links_contents_by_content_substring)(const sc_char * sc_substr, sc_char *** strings, sc_uint32 * size);
+  void (*get_sc_link_content_ext)(sc_element * element, sc_addr addr, sc_char ** sc_string, sc_uint32 * size);
+  sc_bool (*remove_sc_link_content)(sc_element * element, sc_addr addr);
 } sc_fs_storage;
 
 typedef struct _sc_fs_storage_segments_header
@@ -60,7 +61,7 @@ sc_bool sc_fs_storage_append_sc_link(sc_element * element, sc_addr addr, sc_char
  * @param[out] size A sc-links size
  * @returns SC_TRUE, if sc-links exist.
  */
-sc_bool sc_fs_storage_get_sc_links(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size);
+sc_bool sc_fs_storage_get_sc_links_by_content(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size);
 
 /*! Gets sc-links from file system storage by it substring content.
  * @param sc_substr A key substring
@@ -68,29 +69,32 @@ sc_bool sc_fs_storage_get_sc_links(const sc_char * sc_string, sc_addr ** links, 
  * @param[out] size A sc-links size
  * @returns SC_TRUE, if such sc-links exist.
  */
-sc_bool sc_fs_storage_get_sc_links_by_substr(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size);
+sc_bool sc_fs_storage_get_sc_links_by_content_substr(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size);
 
 /*! Gets sc-strings from file system storage by it substring content.
  * @param sc_substr A key substring
- * @param[out] links A pointer to sc-strings array
+ * @param[out] strings A pointer to sc-strings array
  * @param[out] size A sc-strings array size
  * @returns SC_TRUE, if such sc-strings exist.
  */
-sc_bool sc_fs_storage_get_sc_strings_by_substr(const sc_char * sc_substr, sc_char *** strings, sc_uint32 * size);
+sc_bool sc_fs_storage_get_sc_links_contents_by_content_substr(
+    const sc_char * sc_substr,
+    sc_char *** strings,
+    sc_uint32 * size);
 
 /*! Gets sc-link content string with its size.
  * @param addr A sc-link
  * @param[out] sc_string A content string
  * @param[out] size A content string size
  */
-void sc_fs_storage_get_sc_string_ext(sc_element * element, sc_addr addr, sc_char ** sc_string, sc_uint32 * size);
+void sc_fs_storage_get_sc_link_content_ext(sc_element * element, sc_addr addr, sc_char ** sc_string, sc_uint32 * size);
 
 /*! Removes sc-link content string from file system storage.
  * @param element A sc-link element
  * @param addr A sc-link addr
  * @returns SC_TRUE, if such sc-string exists.
  */
-sc_bool sc_fs_storage_remove_sc_string(sc_element * element, sc_addr addr);
+sc_bool sc_fs_storage_remove_sc_link_content(sc_element * element, sc_addr addr);
 
 /*! Loads segments from file system storage.
  * @param segments Pointer to segments array

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage.h
@@ -25,6 +25,7 @@ typedef struct _sc_fs_storage
   sc_bool (*get_sc_links_by_substr)(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size);
   sc_bool (*get_sc_strings_by_substr)(const sc_char * sc_substr, sc_char *** strings, sc_uint32 * size);
   void (*get_sc_string_ext)(sc_element * element, sc_addr addr, sc_char ** sc_string, sc_uint32 * size);
+  sc_bool (*remove_sc_string)(sc_element * element, sc_addr addr);
 } sc_fs_storage;
 
 typedef struct _sc_fs_storage_segments_header
@@ -83,6 +84,13 @@ sc_bool sc_fs_storage_get_sc_strings_by_substr(const sc_char * sc_substr, sc_cha
  * @param[out] size A content string size
  */
 void sc_fs_storage_get_sc_string_ext(sc_element * element, sc_addr addr, sc_char ** sc_string, sc_uint32 * size);
+
+/*! Removes sc-link content string from file system storage.
+ * @param element A sc-link element
+ * @param addr A sc-link addr
+ * @returns SC_TRUE, if such sc-string exists.
+ */
+sc_bool sc_fs_storage_remove_sc_string(sc_element * element, sc_addr addr);
 
 /*! Loads segments from file system storage.
  * @param segments Pointer to segments array

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage_builder.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage_builder.h
@@ -36,7 +36,8 @@ sc_fs_storage * sc_fs_storage_build()
   storage->clear = sc_rocksdb_fs_storage_clear;
   storage->append_sc_link = sc_rocksdb_fs_storage_append_sc_link;
   storage->get_sc_links = sc_rocksdb_fs_storage_get_sc_links;
-  storage->get_sc_links_by_substr = sc_rocksdb_fs_storage_get_sc_links_by_substr;
+  storage->get_sc_links_by_substr = sc_rocksdb_fs_storage_find_sc_links_by_substr;
+  storage->get_sc_strings_by_substr = sc_rocksdb_fs_storage_find_sc_strings_by_substr;
   storage->get_sc_string_ext = sc_rocksdb_fs_storage_get_sc_string_ext;
 #endif
 

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage_builder.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage_builder.h
@@ -26,6 +26,7 @@ sc_fs_storage * sc_fs_storage_build()
   storage->append_sc_link = sc_dictionary_fs_storage_append_sc_link;
   storage->get_sc_links = sc_dictionary_fs_storage_get_sc_links;
   storage->get_sc_links_by_substr = sc_dictionary_fs_storage_get_sc_links_by_substr;
+  storage->get_sc_strings_by_substr = sc_dictionary_fs_storage_get_sc_strings_by_substr;
   storage->get_sc_string_ext = sc_dictionary_fs_storage_get_sc_string_ext;
 #elif SC_ROCKSDB_FS_STORAGE
   storage->initialize = sc_rocksdb_fs_storage_initialize;

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage_builder.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage_builder.h
@@ -23,24 +23,25 @@ sc_fs_storage * sc_fs_storage_build()
   storage->fill = sc_dictionary_fs_storage_fill;
   storage->save = sc_dictionary_fs_storage_save;
   storage->clear = null_ptr;
-  storage->append_sc_link = sc_dictionary_fs_storage_append_sc_link;
-  storage->get_sc_links = sc_dictionary_fs_storage_get_sc_links;
-  storage->get_sc_links_by_substr = sc_dictionary_fs_storage_get_sc_links_by_substr;
-  storage->get_sc_strings_by_substr = sc_dictionary_fs_storage_get_sc_strings_by_substr;
-  storage->get_sc_string_ext = sc_dictionary_fs_storage_get_sc_string_ext;
-  storage->remove_sc_string = sc_dictionary_fs_storage_remove_sc_string;
+  storage->append_sc_link_content = sc_dictionary_fs_storage_append_sc_link_content;
+  storage->get_sc_links_by_content = sc_dictionary_fs_storage_get_sc_links_by_content;
+  storage->get_sc_links_by_content_substring = sc_dictionary_fs_storage_get_sc_links_by_content_substr;
+  storage->get_sc_links_contents_by_content_substring =
+      sc_dictionary_fs_storage_get_sc_links_contents_by_content_substr;
+  storage->get_sc_link_content_ext = sc_dictionary_fs_storage_get_sc_link_content_ext;
+  storage->remove_sc_link_content = sc_dictionary_fs_storage_remove_sc_link_content;
 #elif SC_ROCKSDB_FS_STORAGE
   storage->initialize = sc_rocksdb_fs_storage_initialize;
   storage->shutdown = sc_rocksdb_fs_storage_shutdown;
   storage->fill = null_ptr;
   storage->save = sc_rocksdb_fs_storage_save;
   storage->clear = sc_rocksdb_fs_storage_clear;
-  storage->append_sc_link = sc_rocksdb_fs_storage_append_sc_link;
-  storage->get_sc_links = sc_rocksdb_fs_storage_get_sc_links;
-  storage->get_sc_links_by_substr = sc_rocksdb_fs_storage_find_sc_links_by_substr;
-  storage->get_sc_strings_by_substr = sc_rocksdb_fs_storage_find_sc_strings_by_substr;
-  storage->get_sc_string_ext = sc_rocksdb_fs_storage_get_sc_string_ext;
-  storage->remove_sc_string = sc_rocksdb_fs_storage_remove_sc_string;
+  storage->append_sc_link_content = sc_rocksdb_fs_storage_append_sc_link_content;
+  storage->get_sc_links_by_content = sc_rocksdb_fs_storage_get_sc_links_by_content;
+  storage->get_sc_links_by_content_substring = sc_rocksdb_fs_storage_find_sc_links_by_content_substr;
+  storage->get_sc_links_contents_by_content_substring = sc_rocksdb_fs_storage_find_sc_links_contents_by_content_substr;
+  storage->get_sc_link_content_ext = sc_rocksdb_fs_storage_get_sc_link_content_ext;
+  storage->remove_sc_link_content = sc_rocksdb_fs_storage_remove_sc_link_content;
 #endif
 
   return storage;

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage_builder.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage_builder.h
@@ -28,6 +28,7 @@ sc_fs_storage * sc_fs_storage_build()
   storage->get_sc_links_by_substr = sc_dictionary_fs_storage_get_sc_links_by_substr;
   storage->get_sc_strings_by_substr = sc_dictionary_fs_storage_get_sc_strings_by_substr;
   storage->get_sc_string_ext = sc_dictionary_fs_storage_get_sc_string_ext;
+  storage->remove_sc_string = sc_dictionary_fs_storage_remove_sc_string;
 #elif SC_ROCKSDB_FS_STORAGE
   storage->initialize = sc_rocksdb_fs_storage_initialize;
   storage->shutdown = sc_rocksdb_fs_storage_shutdown;
@@ -39,6 +40,7 @@ sc_fs_storage * sc_fs_storage_build()
   storage->get_sc_links_by_substr = sc_rocksdb_fs_storage_find_sc_links_by_substr;
   storage->get_sc_strings_by_substr = sc_rocksdb_fs_storage_find_sc_strings_by_substr;
   storage->get_sc_string_ext = sc_rocksdb_fs_storage_get_sc_string_ext;
+  storage->remove_sc_string = sc_dictionary_fs_storage_remove_sc_string;
 #endif
 
   return storage;

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage_builder.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_fs_storage_builder.h
@@ -40,7 +40,7 @@ sc_fs_storage * sc_fs_storage_build()
   storage->get_sc_links_by_substr = sc_rocksdb_fs_storage_find_sc_links_by_substr;
   storage->get_sc_strings_by_substr = sc_rocksdb_fs_storage_find_sc_strings_by_substr;
   storage->get_sc_string_ext = sc_rocksdb_fs_storage_get_sc_string_ext;
-  storage->remove_sc_string = sc_dictionary_fs_storage_remove_sc_string;
+  storage->remove_sc_string = sc_rocksdb_fs_storage_remove_sc_string;
 #endif
 
   return storage;

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_rocksdb_fs_storage.cpp
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_rocksdb_fs_storage.cpp
@@ -14,6 +14,7 @@ extern "C"
 }
 
 #  include "../sc-base/sc_allocator.h"
+#  include "../sc-container/sc-string/sc_string.h"
 #  include "../sc-base/sc_message.h"
 
 #  include "rocksdb/db.h"
@@ -265,7 +266,10 @@ sc_result sc_rocksdb_fs_storage_find(const sc_check_sum * check_sum, sc_addr ** 
   return SC_RESULT_OK;
 }
 
-sc_result sc_rocksdb_fs_storage_find_by_substr(const sc_char * sc_substr, sc_addr ** result, sc_uint32 * result_count)
+sc_bool sc_rocksdb_fs_storage_find_sc_links_by_substr(
+    const sc_char * sc_substr,
+    sc_addr ** result,
+    sc_uint32 * result_count)
 {
   MutexGuard lock(gMutex);
 
@@ -312,7 +316,49 @@ sc_result sc_rocksdb_fs_storage_find_by_substr(const sc_char * sc_substr, sc_add
   *result = (sc_addr *)malloc(resultBytes);
   sc_mem_cpy(*result, foundAddrs.data(), resultBytes);
 
-  return SC_RESULT_OK;
+  return SC_TRUE;
+}
+
+sc_bool sc_rocksdb_fs_storage_find_sc_strings_by_substr(
+    const sc_char * sc_substr,
+    sc_char *** result,
+    sc_uint32 * result_count)
+{
+  MutexGuard lock(gMutex);
+
+  assert(gDBInstance);
+
+  rocksdb::ReadOptions readOptions;
+  auto const & it = gDBInstance->NewIterator(readOptions);
+  it->SeekToFirst();
+
+  std::vector<std::string> foundStrings;
+  while (it->Valid())
+  {
+    auto const & slice = it->value();
+
+    std::string str{slice.data()};
+    str.resize(slice.size());
+
+    if (str.find(sc_substr) != std::string::npos)
+    {
+      foundStrings.emplace_back(str);
+    }
+
+    it->Next();
+  }
+
+  *result_count = sc_uint32(foundStrings.size());
+
+  size_t const resultBytes = sizeof(sc_char *) * foundStrings.size();
+  *result = (sc_char **)malloc(resultBytes);
+  for (size_t i = 0; i < foundStrings.size(); ++i)
+  {
+    std::string str = foundStrings[i];
+    sc_str_cpy((*result)[i], str.c_str(), str.size());
+  }
+
+  return SC_TRUE;
 }
 
 sc_bool sc_rocksdb_fs_storage_append_sc_link(sc_element * element, sc_addr addr, sc_char * sc_string, sc_uint32 size)
@@ -347,11 +393,6 @@ sc_bool sc_rocksdb_fs_storage_get_sc_links(const sc_char * sc_string, sc_addr **
   sc_mem_free(check_sum);
 
   return result;
-}
-
-sc_bool sc_rocksdb_fs_storage_get_sc_links_by_substr(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size)
-{
-  return sc_rocksdb_fs_storage_find_by_substr(sc_substr, links, size);
 }
 
 void sc_rocksdb_fs_storage_get_sc_string_ext(sc_element * element, sc_addr addr, sc_char ** sc_string, sc_uint32 * size)

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_rocksdb_fs_storage.cpp
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_rocksdb_fs_storage.cpp
@@ -266,7 +266,7 @@ sc_result sc_rocksdb_fs_storage_find(const sc_check_sum * check_sum, sc_addr ** 
   return SC_RESULT_OK;
 }
 
-sc_bool sc_rocksdb_fs_storage_find_sc_links_by_substr(
+sc_bool sc_rocksdb_fs_storage_find_sc_links_by_content_substr(
     const sc_char * sc_substr,
     sc_addr ** result,
     sc_uint32 * result_count)
@@ -319,7 +319,7 @@ sc_bool sc_rocksdb_fs_storage_find_sc_links_by_substr(
   return SC_TRUE;
 }
 
-sc_bool sc_rocksdb_fs_storage_find_sc_strings_by_substr(
+sc_bool sc_rocksdb_fs_storage_find_sc_links_contents_by_content_substr(
     const sc_char * sc_substr,
     sc_char *** result,
     sc_uint32 * result_count)
@@ -361,11 +361,15 @@ sc_bool sc_rocksdb_fs_storage_find_sc_strings_by_substr(
   return SC_TRUE;
 }
 
-sc_bool sc_rocksdb_fs_storage_append_sc_link(sc_element * element, sc_addr addr, sc_char * sc_string, sc_uint32 size)
+sc_bool sc_rocksdb_fs_storage_append_sc_link_content(
+    sc_element * element,
+    sc_addr addr,
+    sc_char * sc_string,
+    sc_uint32 size)
 {
   sc_char * current_string;
   sc_uint32 current_size = 0;
-  sc_rocksdb_fs_storage_get_sc_string_ext(element, addr, &current_string, &current_size);
+  sc_rocksdb_fs_storage_get_sc_link_content_ext(element, addr, &current_string, &current_size);
 
   if (current_size != 0 && current_string != null_ptr)
   {
@@ -384,7 +388,7 @@ sc_bool sc_rocksdb_fs_storage_append_sc_link(sc_element * element, sc_addr addr,
   return SC_TRUE;
 }
 
-sc_bool sc_rocksdb_fs_storage_get_sc_links(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size)
+sc_bool sc_rocksdb_fs_storage_get_sc_links_by_content(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size)
 {
   sc_check_sum * check_sum;
   sc_link_calculate_checksum(sc_string, strlen(sc_string), &check_sum);
@@ -395,7 +399,11 @@ sc_bool sc_rocksdb_fs_storage_get_sc_links(const sc_char * sc_string, sc_addr **
   return result;
 }
 
-void sc_rocksdb_fs_storage_get_sc_string_ext(sc_element * element, sc_addr addr, sc_char ** sc_string, sc_uint32 * size)
+void sc_rocksdb_fs_storage_get_sc_link_content_ext(
+    sc_element * element,
+    sc_addr addr,
+    sc_char ** sc_string,
+    sc_uint32 * size)
 {
   sc_check_sum check_sum;
   sc_mem_cpy(check_sum.data, element->content.data, SC_CHECKSUM_LEN);
@@ -415,11 +423,11 @@ void sc_rocksdb_fs_storage_get_sc_string_ext(sc_element * element, sc_addr addr,
   }
 }
 
-sc_bool sc_rocksdb_fs_storage_remove_sc_string(sc_element * element, sc_addr addr)
+sc_bool sc_rocksdb_fs_storage_remove_sc_link_content(sc_element * element, sc_addr addr)
 {
   sc_char * string;
   sc_uint32 size = 0;
-  sc_rocksdb_fs_storage_get_sc_string_ext(element, addr, &string, &size);
+  sc_rocksdb_fs_storage_get_sc_link_content_ext(element, addr, &string, &size);
 
   if (size != 0 && string != null_ptr)
   {

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_rocksdb_fs_storage.cpp
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_rocksdb_fs_storage.cpp
@@ -415,4 +415,22 @@ void sc_rocksdb_fs_storage_get_sc_string_ext(sc_element * element, sc_addr addr,
   }
 }
 
+sc_bool sc_rocksdb_fs_storage_remove_sc_string(sc_element * element, sc_addr addr)
+{
+  sc_char * string;
+  sc_uint32 size = 0;
+  sc_rocksdb_fs_storage_get_sc_string_ext(element, addr, &string, &size);
+
+  if (size != 0 && string != null_ptr)
+  {
+    sc_check_sum * check_sum;
+    sc_link_calculate_checksum(string, size, &check_sum);
+    sc_rocksdb_fs_storage_addr_ref_remove(addr, check_sum);
+
+    return SC_TRUE;
+  }
+
+  return SC_FALSE;
+}
+
 #endif

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_rocksdb_fs_storage.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_rocksdb_fs_storage.h
@@ -31,7 +31,11 @@ sc_bool sc_rocksdb_fs_storage_save();
  * @param size A key string size
  * @returns SC_TRUE, if link was added
  */
-sc_bool sc_rocksdb_fs_storage_append_sc_link(sc_element * element, sc_addr addr, sc_char * sc_string, sc_uint32 size);
+sc_bool sc_rocksdb_fs_storage_append_sc_link_content(
+    sc_element * element,
+    sc_addr addr,
+    sc_char * sc_string,
+    sc_uint32 size);
 
 /*! Gets sc-links from sc-rocksdb by it string content.
  * @param sc_string A key string
@@ -39,7 +43,7 @@ sc_bool sc_rocksdb_fs_storage_append_sc_link(sc_element * element, sc_addr addr,
  * @param[out] size A sc-links size
  * @returns SC_TRUE, if sc-links exist.
  */
-sc_bool sc_rocksdb_fs_storage_get_sc_links(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size);
+sc_bool sc_rocksdb_fs_storage_get_sc_links_by_content(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size);
 
 /*! Finds sc-links in sc-rocksdb by it substring content.
  * @param sc_substr A key substring
@@ -47,7 +51,10 @@ sc_bool sc_rocksdb_fs_storage_get_sc_links(const sc_char * sc_string, sc_addr **
  * @param[out] size A sc-links size
  * @returns SC_TRUE, if sc-links exist.
  */
-sc_bool sc_rocksdb_fs_storage_find_sc_links_by_substr(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size);
+sc_bool sc_rocksdb_fs_storage_find_sc_links_by_content_substr(
+    const sc_char * sc_substr,
+    sc_addr ** links,
+    sc_uint32 * size);
 
 /*! Gets sc-strings from sc-rocksdb by it substring.
  * @param sc_substr A key substring
@@ -55,7 +62,7 @@ sc_bool sc_rocksdb_fs_storage_find_sc_links_by_substr(const sc_char * sc_substr,
  * @param[out] size A sc-links size
  * @returns SC_TRUE, if sc-strings array exist.
  */
-sc_bool sc_rocksdb_fs_storage_find_sc_strings_by_substr(
+sc_bool sc_rocksdb_fs_storage_find_sc_links_contents_by_content_substr(
     const sc_char * sc_substr,
     sc_char *** strings,
     sc_uint32 * size);
@@ -66,23 +73,17 @@ sc_bool sc_rocksdb_fs_storage_find_sc_strings_by_substr(
  * @param[out] sc_string A content string
  * @param[out] size A content string size
  */
-void sc_rocksdb_fs_storage_get_sc_string_ext(
+void sc_rocksdb_fs_storage_get_sc_link_content_ext(
     sc_element * element,
     sc_addr addr,
     sc_char ** sc_string,
     sc_uint32 * size);
-
-/*! Gets sc-link content string.
- * @param addr A sc-link
- * @returns A content string.
- */
-sc_char * sc_rocksdb_fs_storage_get_sc_string(sc_addr addr);
 
 /*! Removes sc-link content string from sc-rocksdb.
  * @param element A sc-link element
  * @param addr A sc-link addr
  * @returns SC_TRUE, if such sc-link exists in sc-rocksdb.
  */
-sc_bool sc_rocksdb_fs_storage_remove_sc_string(sc_element * element, sc_addr addr);
+sc_bool sc_rocksdb_fs_storage_remove_sc_link_content(sc_element * element, sc_addr addr);
 
 #endif  // _sc_rocksdb_fs_storage_h_

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_rocksdb_fs_storage.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_rocksdb_fs_storage.h
@@ -41,13 +41,24 @@ sc_bool sc_rocksdb_fs_storage_append_sc_link(sc_element * element, sc_addr addr,
  */
 sc_bool sc_rocksdb_fs_storage_get_sc_links(const sc_char * sc_string, sc_addr ** links, sc_uint32 * size);
 
-/*! Gets sc-links from sc-rocksdb by it substring content.
+/*! Finds sc-links in sc-rocksdb by it substring content.
  * @param sc_substr A key substring
  * @param[out] links A pointer to sc-links
  * @param[out] size A sc-links size
  * @returns SC_TRUE, if sc-links exist.
  */
-sc_bool sc_rocksdb_fs_storage_get_sc_links_by_substr(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size);
+sc_bool sc_rocksdb_fs_storage_find_sc_links_by_substr(const sc_char * sc_substr, sc_addr ** links, sc_uint32 * size);
+
+/*! Gets sc-strings from sc-rocksdb by it substring.
+ * @param sc_substr A key substring
+ * @param[out] strings A pointer to sc-string array
+ * @param[out] size A sc-links size
+ * @returns SC_TRUE, if sc-strings array exist.
+ */
+sc_bool sc_rocksdb_fs_storage_find_sc_strings_by_substr(
+    const sc_char * sc_substr,
+    sc_char *** strings,
+    sc_uint32 * size);
 
 /*! Gets sc-link content string with its size.
  * @param addr A sc-link

--- a/sc-memory/sc-core/sc-store/sc-fs-storage/sc_rocksdb_fs_storage.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-storage/sc_rocksdb_fs_storage.h
@@ -78,4 +78,11 @@ void sc_rocksdb_fs_storage_get_sc_string_ext(
  */
 sc_char * sc_rocksdb_fs_storage_get_sc_string(sc_addr addr);
 
+/*! Removes sc-link content string from sc-rocksdb.
+ * @param element A sc-link element
+ * @param addr A sc-link addr
+ * @returns SC_TRUE, if such sc-link exists in sc-rocksdb.
+ */
+sc_bool sc_rocksdb_fs_storage_remove_sc_string(sc_element * element, sc_addr addr);
+
 #endif  // _sc_rocksdb_fs_storage_h_

--- a/sc-memory/sc-core/sc-store/sc_storage.c
+++ b/sc-memory/sc-core/sc-store/sc_storage.c
@@ -472,7 +472,7 @@ sc_result sc_storage_element_free(sc_memory_context * ctx, sc_addr addr)
 
     if (el->flags.type & sc_type_link)
     {
-      sc_fs_storage_remove_sc_string(el, addr);
+      sc_fs_storage_remove_sc_link_content(el, addr);
     }
     else if (el->flags.type & sc_type_arc_mask)
     {
@@ -1013,7 +1013,7 @@ sc_result sc_storage_get_link_content(const sc_memory_context * ctx, sc_addr add
   {
     sc_uint32 size = 0;
     sc_char * sc_string = null_ptr;
-    sc_fs_storage_get_sc_string_ext(el, addr, &sc_string, &size);
+    sc_fs_storage_get_sc_link_content_ext(el, addr, &sc_string, &size);
 
     if (sc_string == null_ptr)
     {
@@ -1051,7 +1051,7 @@ sc_result sc_storage_find_links_with_content(
     return SC_RESULT_ERROR;
 
   sc_addr * found_addrs = null_ptr;
-  sc_result result = sc_fs_storage_get_sc_links(sc_string, &found_addrs, result_count);
+  sc_result result = sc_fs_storage_get_sc_links_by_content(sc_string, &found_addrs, result_count);
   sc_mem_free(sc_string);
   if (result != SC_RESULT_OK || found_addrs == null_ptr || result_count == 0)
     return SC_RESULT_ERROR;
@@ -1114,7 +1114,7 @@ sc_result sc_storage_find_links_by_content_substring(
   if (sc_stream_get_data(stream, &sc_string, &size) != SC_TRUE)
     return SC_RESULT_ERROR;
 
-  sc_result result = sc_fs_storage_get_sc_links_by_substr(sc_string, result_addrs, result_count);
+  sc_result result = sc_fs_storage_get_sc_links_by_content_substr(sc_string, result_addrs, result_count);
   sc_mem_free(sc_string);
   if (result != SC_RESULT_OK)
     return SC_RESULT_ERROR;
@@ -1122,7 +1122,7 @@ sc_result sc_storage_find_links_by_content_substring(
   return result;
 }
 
-sc_result sc_storage_find_strings_by_substring(
+sc_result sc_storage_find_links_contents_by_content_substring(
     const sc_memory_context * ctx,
     const sc_stream * stream,
     sc_char *** result_strings,
@@ -1139,7 +1139,7 @@ sc_result sc_storage_find_strings_by_substring(
   if (sc_stream_get_data(stream, &sc_string, &size) != SC_TRUE)
     return SC_RESULT_ERROR;
 
-  sc_result result = sc_fs_storage_get_sc_strings_by_substr(sc_string, result_strings, result_count);
+  sc_result result = sc_fs_storage_get_sc_links_contents_by_content_substr(sc_string, result_strings, result_count);
   sc_mem_free(sc_string);
   if (result != SC_RESULT_OK)
     return SC_RESULT_ERROR;

--- a/sc-memory/sc-core/sc-store/sc_storage.c
+++ b/sc-memory/sc-core/sc-store/sc_storage.c
@@ -1097,7 +1097,7 @@ sc_result sc_storage_find_links_with_content(
   return result;
 }
 
-sc_result sc_storage_find_links_with_content_substring(
+sc_result sc_storage_find_links_by_content_substring(
     const sc_memory_context * ctx,
     const sc_stream * stream,
     sc_addr ** result_addrs,
@@ -1115,6 +1115,31 @@ sc_result sc_storage_find_links_with_content_substring(
     return SC_RESULT_ERROR;
 
   sc_result result = sc_fs_storage_get_sc_links_by_substr(sc_string, result_addrs, result_count);
+  sc_mem_free(sc_string);
+  if (result != SC_RESULT_OK)
+    return SC_RESULT_ERROR;
+
+  return result;
+}
+
+sc_result sc_storage_find_strings_by_substring(
+    const sc_memory_context * ctx,
+    const sc_stream * stream,
+    sc_char *** result_strings,
+    sc_uint32 * result_count)
+{
+  sc_assert(ctx != null_ptr);
+  sc_assert(stream != null_ptr);
+
+  *result_strings = null_ptr;
+  *result_count = 0;
+
+  sc_char * sc_string = null_ptr;
+  sc_uint32 size = 0;
+  if (sc_stream_get_data(stream, &sc_string, &size) != SC_TRUE)
+    return SC_RESULT_ERROR;
+
+  sc_result result = sc_fs_storage_get_sc_strings_by_substr(sc_string, result_strings, result_count);
   sc_mem_free(sc_string);
   if (result != SC_RESULT_OK)
     return SC_RESULT_ERROR;

--- a/sc-memory/sc-core/sc-store/sc_storage.c
+++ b/sc-memory/sc-core/sc-store/sc_storage.c
@@ -472,7 +472,7 @@ sc_result sc_storage_element_free(sc_memory_context * ctx, sc_addr addr)
 
     if (el->flags.type & sc_type_link)
     {
-      // @todo: Implement effective sc-strings remove
+      sc_fs_storage_remove_sc_string(el, addr);
     }
     else if (el->flags.type & sc_type_arc_mask)
     {

--- a/sc-memory/sc-core/sc-store/sc_storage.h
+++ b/sc-memory/sc-core/sc-store/sc_storage.h
@@ -201,7 +201,7 @@ sc_result sc_storage_find_links_by_content_substring(
  * In any case \p result_count contains number of found sc-strings.
  * @attention \p result array need to be free after usage
  */
-sc_result sc_storage_find_strings_by_substring(
+sc_result sc_storage_find_links_contents_by_content_substring(
     const sc_memory_context * ctx,
     const sc_stream * stream,
     sc_char *** result_strings,

--- a/sc-memory/sc-core/sc-store/sc_storage.h
+++ b/sc-memory/sc-core/sc-store/sc_storage.h
@@ -164,34 +164,47 @@ sc_result sc_storage_get_link_content(sc_memory_context const * ctx, sc_addr add
 
 /*! Search sc-link addrs by specified data
  * @param stream Pointer to stream that contains data for search
- * @param result Pointer to result container
+ * @param result_addrs Pointer to result container
  * @param result_count Container for results count
- * @return If sc-links with specified checksum found, then sc-addrs of found link
- * writes into \p result array and function returns SC_OK; otherwise \p result will contain
- * empty sc-addr and function returns SC_OK. In any case \p result_count contains number of found
- * sc-addrs
+ * @return If sc-links with specified content found, then sc-addrs of found link
+ * writes into \p result array and function returns SC_OK; otherwise \p function returns SC_OK.
+ * In any case \p result_count contains number of found sc-addrs.
  * @attention \p result array need to be free after usage
  */
 sc_result sc_storage_find_links_with_content(
     sc_memory_context const * ctx,
     sc_stream const * stream,
-    sc_addr ** result,
+    sc_addr ** result_addrs,
     sc_uint32 * result_count);
 
 /*! Search sc-link addrs by specified data substring
  * @param stream Pointer to stream that contains data for search
- * @param result Pointer to result container of sc-links with specified data started with substring
+ * @param result_addrs Pointer to result container of sc-links with specified data started with substring
  * @param result_count Container for results count
- * @return If sc-links with specified checksum found, then sc-addrs of found link
- * writes into \p result array and function returns SC_OK; otherwise \p result will contain
- * empty sc-addr and function returns SC_OK. In any case \p result_count contains number of found
- * sc-addrs
+ * @return If sc-links with specified substring found, then sc-addrs of found link
+ * writes into \p result array and function returns SC_RESULT_OK; otherwise function returns SC_RESULT_OK.
+ * In any case \p result_count contains number of found sc-addrs.
  * @attention \p result array need to be free after usage
  */
-sc_result sc_storage_find_links_with_content_substring(
+sc_result sc_storage_find_links_by_content_substring(
     const sc_memory_context * ctx,
     const sc_stream * stream,
     sc_addr ** result_addrs,
+    sc_uint32 * result_count);
+
+/*! Search sc-strings by specified substring
+ * @param stream Pointer to stream that contains data for search
+ * @param result_strings Pointer to result container of sc-strings with substring
+ * @param result_count Container for results count
+ * @return If sc-strings with specified substring found, then they
+ * writes into \p result array and function returns SC_RESULT_OK; otherwise function returns SC_RESULT_OK.
+ * In any case \p result_count contains number of found sc-strings.
+ * @attention \p result array need to be free after usage
+ */
+sc_result sc_storage_find_strings_by_substring(
+    const sc_memory_context * ctx,
+    const sc_stream * stream,
+    sc_char *** result_strings,
     sc_uint32 * result_count);
 
 /*! Setup new access levels to sc-element. New access levels will be a minimum from context access levels and parameter

--- a/sc-memory/sc-core/sc_memory.c
+++ b/sc-memory/sc-core/sc_memory.c
@@ -334,13 +334,13 @@ sc_result sc_memory_find_links_by_content_substring(
   return sc_storage_find_links_by_content_substring(ctx, stream, result, result_count);
 }
 
-sc_result sc_memory_find_strings_by_substring(
+sc_result sc_memory_find_links_contents_by_content_substring(
     sc_memory_context const * ctx,
     sc_stream const * stream,
     sc_char *** result,
     sc_uint32 * result_count)
 {
-  return sc_storage_find_strings_by_substring(ctx, stream, result, result_count);
+  return sc_storage_find_links_contents_by_content_substring(ctx, stream, result, result_count);
 }
 
 void sc_memory_free_buff(sc_pointer buff)

--- a/sc-memory/sc-core/sc_memory.c
+++ b/sc-memory/sc-core/sc_memory.c
@@ -325,13 +325,22 @@ sc_result sc_memory_find_links_with_content(
   return sc_storage_find_links_with_content(ctx, stream, result, result_count);
 }
 
-sc_result sc_memory_find_links_with_content_substring(
+sc_result sc_memory_find_links_by_content_substring(
     sc_memory_context const * ctx,
     sc_stream const * stream,
     sc_addr ** result,
     sc_uint32 * result_count)
 {
-  return sc_storage_find_links_with_content_substring(ctx, stream, result, result_count);
+  return sc_storage_find_links_by_content_substring(ctx, stream, result, result_count);
+}
+
+sc_result sc_memory_find_strings_by_substring(
+    sc_memory_context const * ctx,
+    sc_stream const * stream,
+    sc_char *** result,
+    sc_uint32 * result_count)
+{
+  return sc_storage_find_strings_by_substring(ctx, stream, result, result_count);
 }
 
 void sc_memory_free_buff(sc_pointer buff)

--- a/sc-memory/sc-core/sc_memory.h
+++ b/sc-memory/sc-core/sc_memory.h
@@ -203,7 +203,7 @@ _SC_EXTERN sc_result sc_memory_find_links_by_content_substring(
  * In any case \p result_count contains number of found sc-strings.
  * @attention \p result array need to be free after usage
  */
-_SC_EXTERN sc_result sc_memory_find_strings_by_substring(
+_SC_EXTERN sc_result sc_memory_find_links_contents_by_content_substring(
     sc_memory_context const * ctx,
     sc_stream const * stream,
     sc_char *** result,

--- a/sc-memory/sc-core/sc_memory.h
+++ b/sc-memory/sc-core/sc_memory.h
@@ -163,11 +163,11 @@ _SC_EXTERN sc_result sc_memory_set_link_content(sc_memory_context * ctx, sc_addr
  */
 _SC_EXTERN sc_result sc_memory_get_link_content(sc_memory_context const * ctx, sc_addr addr, sc_stream ** stream);
 
-/*! Search sc-link addrs by specified checksum
+/*! Search sc-link addrs by specified string
  * @param stream Pointert to stream that contains data for search
  * @param result Pointer to result container
  * @param result_count Container for results count
- * @return If sc-links with specified checksum found, then sc-addrs of found link
+ * @return If sc-links with specified string found, then sc-addrs of found link
  * writes into \p result array and function returns SC_RESULT_OK; otherwise \p result will contain
  * empty sc-addr and function returns SC_RESULT_OK. In any case \p result_count contains number of found
  * sc-addrs
@@ -179,20 +179,34 @@ _SC_EXTERN sc_result sc_memory_find_links_with_content(
     sc_addr ** result,
     sc_uint32 * result_count);
 
-/*! Search sc-link addrs by specified checksum substring
- * @param stream Pointert to stream that contains data substring for search
+/*! Search sc-link addrs by specified substring
+ * @param stream Pointer to stream that contains data substring for search
  * @param result Pointer to result container of sc-links
  * @param result_count Container for results count
- * @return If sc-links with specified checksum found, then sc-addrs of found link
- * writes into \p result array and function returns SC_RESULT_OK; otherwise \p result will contain
- * empty sc-addr and function returns SC_RESULT_OK. In any case \p result_count contains number of found
- * sc-addrs
+ * @return If sc-links with specified substring found, then sc-addrs of found link
+ * writes into \p result array and function returns SC_RESULT_OK; otherwise function returns SC_RESULT_OK.
+ * In any case \p result_count contains number of found sc-addrs.
  * @attention \p result array need to be free after usage
  */
-_SC_EXTERN sc_result sc_memory_find_links_with_content_substring(
+_SC_EXTERN sc_result sc_memory_find_links_by_content_substring(
     sc_memory_context const * ctx,
     sc_stream const * stream,
     sc_addr ** result,
+    sc_uint32 * result_count);
+
+/*! Search sc-strings array by specified substring
+ * @param stream Pointer to stream that contains data substring for search
+ * @param result Pointer to result container of sc-strings
+ * @param result_count Container for results count
+ * @return If sc-links with specified checksum found, then found strings
+ * writes into \p result array and function returns SC_RESULT_OK; otherwise function returns SC_RESULT_OK.
+ * In any case \p result_count contains number of found sc-strings.
+ * @attention \p result array need to be free after usage
+ */
+_SC_EXTERN sc_result sc_memory_find_strings_by_substring(
+    sc_memory_context const * ctx,
+    sc_stream const * stream,
+    sc_char *** result,
     sc_uint32 * result_count);
 
 /*! Free buffer allocated for links content find result

--- a/sc-memory/sc-memory/sc_memory.cpp
+++ b/sc-memory/sc-memory/sc_memory.cpp
@@ -390,7 +390,7 @@ ScAddrVector ScMemoryContext::FindLinksByContentSubstring(ScStreamPtr const & st
   return contents;
 }
 
-std::vector<std::string> ScMemoryContext::FindStringsBySubstring(ScStreamPtr const & stream)
+std::vector<std::string> ScMemoryContext::FindLinksContentsByContentSubstring(ScStreamPtr const & stream)
 {
   SC_ASSERT(IsValid(), ());
   std::vector<std::string> contents;
@@ -399,7 +399,7 @@ std::vector<std::string> ScMemoryContext::FindStringsBySubstring(ScStreamPtr con
   sc_uint32 resultCount = 0;
 
   sc_stream * str = stream->m_stream;
-  if (sc_memory_find_strings_by_substring(m_context, str, &result, &resultCount) == SC_RESULT_OK)
+  if (sc_memory_find_links_contents_by_content_substring(m_context, str, &result, &resultCount) == SC_RESULT_OK)
   {
     for (sc_uint32 i = 0; i < resultCount; ++i)
     {

--- a/sc-memory/sc-memory/sc_memory.cpp
+++ b/sc-memory/sc-memory/sc_memory.cpp
@@ -402,7 +402,10 @@ std::vector<std::string> ScMemoryContext::FindStringsBySubstring(ScStreamPtr con
   if (sc_memory_find_strings_by_substring(m_context, str, &result, &resultCount) == SC_RESULT_OK)
   {
     for (sc_uint32 i = 0; i < resultCount; ++i)
+    {
       contents.emplace_back(result[i]);
+      sc_memory_free_buff(result[i]);
+    }
 
     if (result)
       sc_memory_free_buff(result);

--- a/sc-memory/sc-memory/sc_memory.cpp
+++ b/sc-memory/sc-memory/sc_memory.cpp
@@ -378,10 +378,31 @@ ScAddrVector ScMemoryContext::FindLinksByContentSubstring(ScStreamPtr const & st
   sc_uint32 resultCount = 0;
 
   sc_stream * str = stream->m_stream;
-  if (sc_memory_find_links_with_content_substring(m_context, str, &result, &resultCount) == SC_RESULT_OK)
+  if (sc_memory_find_links_by_content_substring(m_context, str, &result, &resultCount) == SC_RESULT_OK)
   {
     for (sc_uint32 i = 0; i < resultCount; ++i)
       contents.push_back(ScAddr(result[i]));
+
+    if (result)
+      sc_memory_free_buff(result);
+  }
+
+  return contents;
+}
+
+std::vector<std::string> ScMemoryContext::FindStringsBySubstring(ScStreamPtr const & stream)
+{
+  SC_ASSERT(IsValid(), ());
+  std::vector<std::string> contents;
+
+  sc_char ** result = nullptr;
+  sc_uint32 resultCount = 0;
+
+  sc_stream * str = stream->m_stream;
+  if (sc_memory_find_strings_by_substring(m_context, str, &result, &resultCount) == SC_RESULT_OK)
+  {
+    for (sc_uint32 i = 0; i < resultCount; ++i)
+      contents.emplace_back(result[i]);
 
     if (result)
       sc_memory_free_buff(result);

--- a/sc-memory/sc-memory/sc_memory.hpp
+++ b/sc-memory/sc-memory/sc_memory.hpp
@@ -171,11 +171,11 @@ public:
   _SC_EXTERN ScAddrVector FindLinksByContentSubstring(ScStreamPtr const & stream);
 
   template <typename TContentType>
-  std::vector<std::string> FindStringsBySubstring(TContentType const & value)
+  std::vector<std::string> FindLinksContentsByContentSubstring(TContentType const & value)
   {
-    return FindStringsBySubstring(ScStreamMakeRead(value));
+    return FindLinksContentsByContentSubstring(ScStreamMakeRead(value));
   }
-  _SC_EXTERN std::vector<std::string> FindStringsBySubstring(ScStreamPtr const & stream);
+  _SC_EXTERN std::vector<std::string> FindLinksContentsByContentSubstring(ScStreamPtr const & stream);
 
   //! Saves memory state
   _SC_EXTERN bool Save();

--- a/sc-memory/sc-memory/sc_memory.hpp
+++ b/sc-memory/sc-memory/sc_memory.hpp
@@ -170,6 +170,13 @@ public:
   }
   _SC_EXTERN ScAddrVector FindLinksByContentSubstring(ScStreamPtr const & stream);
 
+  template <typename TContentType>
+  std::vector<std::string> FindStringsBySubstring(TContentType const & value)
+  {
+    return FindStringsBySubstring(ScStreamMakeRead(value));
+  }
+  _SC_EXTERN std::vector<std::string> FindStringsBySubstring(ScStreamPtr const & stream);
+
   //! Saves memory state
   _SC_EXTERN bool Save();
 

--- a/sc-memory/sc-memory/utils/sc_console.hpp
+++ b/sc-memory/sc-memory/utils/sc_console.hpp
@@ -159,7 +159,7 @@ std::string const & GetANSIColor(ScConsole::Color c);
 }
 
 template <>
-inline ScConsole::Output & ScConsole::Output::operator<< <ScConsole::Color>(ScConsole::Color v)
+inline ScConsole::Output & ScConsole::Output::operator<<<ScConsole::Color>(ScConsole::Color v)
 {
   ScConsole::SetColor(v);
   // std::cout << impl::GetANSIColor(v);

--- a/sc-memory/sc-memory/utils/sc_console.hpp
+++ b/sc-memory/sc-memory/utils/sc_console.hpp
@@ -159,7 +159,7 @@ std::string const & GetANSIColor(ScConsole::Color c);
 }
 
 template <>
-inline ScConsole::Output & ScConsole::Output::operator<<<ScConsole::Color>(ScConsole::Color v)
+inline ScConsole::Output & ScConsole::Output::operator<< <ScConsole::Color>(ScConsole::Color v)
 {
   ScConsole::SetColor(v);
   // std::cout << impl::GetANSIColor(v);

--- a/sc-memory/tests/sc-memory/common/sc-link.cpp
+++ b/sc-memory/tests/sc-memory/common/sc-link.cpp
@@ -215,7 +215,7 @@ TEST_F(ScLinkTest, set_system_idtf)
   ctx.Destroy();
 }
 
-TEST_F(ScLinkTest, find_by_substr)
+TEST_F(ScLinkTest, find_links_by_substr)
 {
   ScMemoryContext ctx(sc_access_lvl_make_min, "sc_links_content_changed");
 
@@ -229,29 +229,30 @@ TEST_F(ScLinkTest, find_by_substr)
   linkAddr = ctx.CreateLink();
   EXPECT_TRUE(linkAddr.IsValid());
   ScLink link2 = ScLink(ctx, linkAddr);
-  str = "continue";
+  str = "ton_content";
   EXPECT_TRUE(link2.Set(str));
   EXPECT_TRUE(str == link2.GetAsString());
 
   linkAddr = ctx.CreateLink();
   EXPECT_TRUE(linkAddr.IsValid());
   ScLink link3 = ScLink(ctx, linkAddr);
-  str = "contents_25";
+  str = "cotents_25";
   EXPECT_TRUE(link3.Set(str));
   EXPECT_TRUE(str == link3.GetAsString());
 
   EXPECT_FALSE(ctx.FindLinksByContent("content1").empty());
-  EXPECT_FALSE(ctx.FindLinksByContent("continue").empty());
-  EXPECT_FALSE(ctx.FindLinksByContent("contents_25").empty());
+  EXPECT_FALSE(ctx.FindLinksByContent("ton_content").empty());
+  EXPECT_FALSE(ctx.FindLinksByContent("cotents_25").empty());
 
   EXPECT_TRUE(ctx.FindLinksByContentSubstring("content1").size() == 1);
-  EXPECT_TRUE(ctx.FindLinksByContentSubstring("cont").size() == 3);
+  EXPECT_TRUE(ctx.FindLinksByContentSubstring("cont").size() == 2);
   EXPECT_TRUE(ctx.FindLinksByContentSubstring("content").size() == 2);
-  EXPECT_TRUE(ctx.FindLinksByContentSubstring("con").size() == 3);
+  EXPECT_TRUE(ctx.FindLinksByContentSubstring("on").size() == 3);
+  EXPECT_TRUE(ctx.FindLinksByContentSubstring("con").size() == 2);
   EXPECT_TRUE(ctx.FindLinksByContentSubstring("content2").empty());
-  EXPECT_TRUE(ctx.FindLinksByContentSubstring("contents").size() == 1);
-  EXPECT_TRUE(ctx.FindLinksByContentSubstring("contents_2").size() == 1);
-  EXPECT_TRUE(ctx.FindLinksByContentSubstring("contents_26").empty());
+  EXPECT_TRUE(ctx.FindLinksByContentSubstring("contents").empty());
+  EXPECT_TRUE(ctx.FindLinksByContentSubstring("cotents_2").size() == 1);
+  EXPECT_TRUE(ctx.FindLinksByContentSubstring("cotents_26").empty());
 
   ctx.Destroy();
 }

--- a/sc-memory/tests/sc-memory/common/sc-link.cpp
+++ b/sc-memory/tests/sc-memory/common/sc-link.cpp
@@ -5,6 +5,8 @@
 
 #include "sc_test.hpp"
 
+#include <algorithm>
+
 template <typename Type> void TestType(ScMemoryContext & ctx, Type const & value)
 {
   ScAddr const linkAddr = ctx.CreateLink();
@@ -253,6 +255,57 @@ TEST_F(ScLinkTest, find_links_by_substr)
   EXPECT_TRUE(ctx.FindLinksByContentSubstring("contents").empty());
   EXPECT_TRUE(ctx.FindLinksByContentSubstring("cotents_2").size() == 1);
   EXPECT_TRUE(ctx.FindLinksByContentSubstring("cotents_26").empty());
+
+  ctx.Destroy();
+}
+
+TEST_F(ScLinkTest, find_strings_by_substr)
+{
+  ScMemoryContext ctx(sc_access_lvl_make_min, "sc_links_content_changed");
+
+  ScAddr linkAddr = ctx.CreateLink();
+  EXPECT_TRUE(linkAddr.IsValid());
+  ScLink link1 = ScLink(ctx, linkAddr);
+  std::string str = "some coten";
+  EXPECT_TRUE(link1.Set(str));
+  EXPECT_TRUE(str == link1.GetAsString());
+
+  linkAddr = ctx.CreateLink();
+  EXPECT_TRUE(linkAddr.IsValid());
+  ScLink link2 = ScLink(ctx, linkAddr);
+  str = "ton_content";
+  EXPECT_TRUE(link2.Set(str));
+  EXPECT_TRUE(str == link2.GetAsString());
+
+  linkAddr = ctx.CreateLink();
+  EXPECT_TRUE(linkAddr.IsValid());
+  ScLink link3 = ScLink(ctx, linkAddr);
+  str = "content_tents_25";
+  EXPECT_TRUE(link3.Set(str));
+  EXPECT_TRUE(str == link3.GetAsString());
+
+  EXPECT_FALSE(ctx.FindStringsBySubstring("some coten").empty());
+  EXPECT_FALSE(ctx.FindStringsBySubstring("ton_content").empty());
+  EXPECT_FALSE(ctx.FindStringsBySubstring("content_tents_25").empty());
+
+  auto strings = ctx.FindStringsBySubstring("some coten");
+  EXPECT_TRUE(ctx.FindStringsBySubstring("some coten").size() == 1);
+  EXPECT_TRUE(strings[0] == "some coten");
+
+  strings = ctx.FindStringsBySubstring("cont");
+  EXPECT_TRUE(strings.size() == 2);
+  EXPECT_TRUE(std::find(strings.begin(), strings.end(), "ton_content") != strings.end());
+  EXPECT_TRUE(std::find(strings.begin(), strings.end(), "content_tents_25") != strings.end());
+
+  strings = ctx.FindStringsBySubstring("25");
+  EXPECT_TRUE(strings.size() == 1);
+  EXPECT_TRUE(std::find(strings.begin(), strings.end(), "content_tents_25") != strings.end());
+
+  strings = ctx.FindStringsBySubstring("co");
+  EXPECT_TRUE(strings.size() >= 3);
+  EXPECT_TRUE(std::find(strings.begin(), strings.end(), "some coten") != strings.end());
+  EXPECT_TRUE(std::find(strings.begin(), strings.end(), "ton_content") != strings.end());
+  EXPECT_TRUE(std::find(strings.begin(), strings.end(), "content_tents_25") != strings.end());
 
   ctx.Destroy();
 }

--- a/sc-memory/tests/sc-memory/common/sc-link.cpp
+++ b/sc-memory/tests/sc-memory/common/sc-link.cpp
@@ -284,24 +284,24 @@ TEST_F(ScLinkTest, find_strings_by_substr)
   EXPECT_TRUE(link3.Set(str));
   EXPECT_TRUE(str == link3.GetAsString());
 
-  EXPECT_FALSE(ctx.FindStringsBySubstring("some coten").empty());
-  EXPECT_FALSE(ctx.FindStringsBySubstring("ton_content").empty());
-  EXPECT_FALSE(ctx.FindStringsBySubstring("content_tents_25").empty());
+  EXPECT_FALSE(ctx.FindLinksContentsByContentSubstring("some coten").empty());
+  EXPECT_FALSE(ctx.FindLinksContentsByContentSubstring("ton_content").empty());
+  EXPECT_FALSE(ctx.FindLinksContentsByContentSubstring("content_tents_25").empty());
 
-  auto strings = ctx.FindStringsBySubstring("some coten");
-  EXPECT_TRUE(ctx.FindStringsBySubstring("some coten").size() == 1);
+  auto strings = ctx.FindLinksContentsByContentSubstring("some coten");
+  EXPECT_TRUE(ctx.FindLinksContentsByContentSubstring("some coten").size() == 1);
   EXPECT_TRUE(strings[0] == "some coten");
 
-  strings = ctx.FindStringsBySubstring("cont");
+  strings = ctx.FindLinksContentsByContentSubstring("cont");
   EXPECT_TRUE(strings.size() == 2);
   EXPECT_TRUE(std::find(strings.begin(), strings.end(), "ton_content") != strings.end());
   EXPECT_TRUE(std::find(strings.begin(), strings.end(), "content_tents_25") != strings.end());
 
-  strings = ctx.FindStringsBySubstring("25");
+  strings = ctx.FindLinksContentsByContentSubstring("25");
   EXPECT_TRUE(strings.size() == 1);
   EXPECT_TRUE(std::find(strings.begin(), strings.end(), "content_tents_25") != strings.end());
 
-  strings = ctx.FindStringsBySubstring("co");
+  strings = ctx.FindLinksContentsByContentSubstring("co");
   EXPECT_TRUE(strings.size() >= 3);
   EXPECT_TRUE(std::find(strings.begin(), strings.end(), "some coten") != strings.end());
   EXPECT_TRUE(std::find(strings.begin(), strings.end(), "ton_content") != strings.end());

--- a/sc-memory/tests/sc-memory/common/sc-link.cpp
+++ b/sc-memory/tests/sc-memory/common/sc-link.cpp
@@ -302,6 +302,7 @@ TEST_F(ScLinkTest, find_strings_by_substr)
   EXPECT_TRUE(std::find(strings.begin(), strings.end(), "content_tents_25") != strings.end());
 
   strings = ctx.FindLinksContentsByContentSubstring("co");
+  // there are another links as system identifiers of resolve keynodes after sc-server start
   EXPECT_TRUE(strings.size() >= 3);
   EXPECT_TRUE(std::find(strings.begin(), strings.end(), "some coten") != strings.end());
   EXPECT_TRUE(std::find(strings.begin(), strings.end(), "ton_content") != strings.end());

--- a/sc-memory/tests/sc-memory/containers/sc-dictionary.cpp
+++ b/sc-memory/tests/sc-memory/containers/sc-dictionary.cpp
@@ -37,54 +37,71 @@ TEST_F(ScDictionaryTest, smoke)
       _test_sc_dictionary_addr_hashes_int_to_char));
 
   sc_addr addr1 = sc_memory_link_new(m_ctx->GetRealContext());
-  sc_char * str1 = "concept_set1";
+  sc_char const * str1 = "concept_set1";
   sc_dictionary_append(dictionary, str1, strlen(str1), &addr1);
   EXPECT_TRUE(sc_dictionary_is_in(dictionary, str1));
 
   sc_addr addr2 = sc_memory_link_new(m_ctx->GetRealContext());
-  sc_char * str2 = "concept_letter";
+  sc_char const * str2 = "concept_concept";
   sc_dictionary_append(dictionary, str2, strlen(str2), &addr2);
   EXPECT_TRUE(sc_dictionary_is_in(dictionary, str2));
   EXPECT_TRUE(sc_dictionary_is_in(dictionary, str1));
 
   sc_addr addr3 = sc_memory_link_new(m_ctx->GetRealContext());
-  sc_char * str3 = "sc_node_norole_relation";
+  sc_char const * str3 = "norole_relation";
   sc_dictionary_append(dictionary, str3, strlen(str3), &addr3);
   EXPECT_TRUE(sc_dictionary_is_in(dictionary, str3));
   EXPECT_TRUE(sc_dictionary_is_in(dictionary, str2));
   EXPECT_TRUE(sc_dictionary_is_in(dictionary, str1));
 
   sc_addr addr4 = sc_memory_link_new(m_ctx->GetRealContext());
-  sc_char * str4 = "sc_node_role_relation";
+  sc_char const * str4 = "node_role_relation";
   sc_dictionary_append(dictionary, str4, strlen(str4), &addr4);
   EXPECT_TRUE(sc_dictionary_is_in(dictionary, str4));
   EXPECT_TRUE(sc_dictionary_is_in(dictionary, str3));
   EXPECT_TRUE(sc_dictionary_is_in(dictionary, str2));
   EXPECT_TRUE(sc_dictionary_is_in(dictionary, str1));
 
-  EXPECT_TRUE(sc_dictionary_remove(dictionary, str4));
-  EXPECT_FALSE(sc_dictionary_is_in(dictionary, str4));
-  EXPECT_TRUE(sc_dictionary_is_in(dictionary, str3));
-  EXPECT_TRUE(sc_dictionary_is_in(dictionary, str2));
-  EXPECT_TRUE(sc_dictionary_is_in(dictionary, str1));
+  auto const checkAfterRemove
+      = [dictionary](
+            sc_char const * stringToRemove,
+            std::unordered_map<sc_char const *, sc_addr> const & toCheckExistence,
+            std::unordered_map<sc_char const *, sc_addr> const & toCheckNonExistence) {
+    auto const checkExistence = [dictionary](sc_char const * string, sc_addr addr) {
+      EXPECT_TRUE(sc_dictionary_is_in(dictionary, string));
+      sc_list * list = sc_dictionary_get(dictionary, string);
+      sc_iterator * it = sc_list_iterator(list);
+      EXPECT_TRUE(sc_iterator_next(it));
+      EXPECT_TRUE(SC_ADDR_IS_EQUAL(*(sc_addr *)sc_iterator_get(it), addr));
+      EXPECT_FALSE(sc_iterator_next(it));
+      EXPECT_TRUE(sc_iterator_destroy(it));
+    };
 
-  EXPECT_TRUE(sc_dictionary_remove(dictionary, str3));
-  EXPECT_FALSE(sc_dictionary_is_in(dictionary, str4));
-  EXPECT_FALSE(sc_dictionary_is_in(dictionary, str3));
-  EXPECT_TRUE(sc_dictionary_is_in(dictionary, str2));
-  EXPECT_TRUE(sc_dictionary_is_in(dictionary, str1));
+    for (auto const & item : toCheckExistence)
+    {
+      checkExistence(item.first, item.second);
+    }
 
-  EXPECT_TRUE(sc_dictionary_remove(dictionary, str2));
-  EXPECT_FALSE(sc_dictionary_is_in(dictionary, str4));
-  EXPECT_FALSE(sc_dictionary_is_in(dictionary, str3));
-  EXPECT_FALSE(sc_dictionary_is_in(dictionary, str2));
-  EXPECT_TRUE(sc_dictionary_is_in(dictionary, str1));
+    EXPECT_TRUE(sc_dictionary_remove(dictionary, stringToRemove));
 
-  EXPECT_TRUE(sc_dictionary_remove(dictionary, str1));
-  EXPECT_FALSE(sc_dictionary_is_in(dictionary, str4));
-  EXPECT_FALSE(sc_dictionary_is_in(dictionary, str3));
-  EXPECT_FALSE(sc_dictionary_is_in(dictionary, str2));
-  EXPECT_FALSE(sc_dictionary_is_in(dictionary, str1));
+    auto const checkNonExistence = [dictionary](sc_char const * string, sc_addr addr) {
+      EXPECT_FALSE(sc_dictionary_is_in(dictionary, string));
+      sc_list * list = sc_dictionary_get(dictionary, string);
+      sc_iterator * it = sc_list_iterator(list);
+      EXPECT_FALSE(sc_iterator_next(it));
+      EXPECT_TRUE(it == nullptr || sc_iterator_destroy(it));
+    };
+
+    for (auto const & item : toCheckNonExistence)
+    {
+      checkNonExistence(item.first, item.second);
+    }
+  };
+
+  checkAfterRemove(str1, {{str2, addr2}, {str3, addr3}, {str4, addr4}}, {{str1, addr1}});
+  checkAfterRemove(str2, {{str3, addr3}, {str4, addr4}}, {{str1, addr1}, {str2, addr2}});
+  checkAfterRemove(str3, {{str4, addr4}}, {{str1, addr1}, {str2, addr2}, {str3, addr3}});
+  checkAfterRemove(str4, {}, {{str1, addr1}, {str2, addr2}, {str3, addr3}, {str4, addr4}});
 
   sc_dictionary_destroy(dictionary, sc_dictionary_node_destroy);
 }

--- a/sc-memory/tests/sc-memory/containers/sc-dictionary.cpp
+++ b/sc-memory/tests/sc-memory/containers/sc-dictionary.cpp
@@ -22,19 +22,13 @@ void _test_sc_dictionary_addr_hashes_char_to_int(sc_char ch, sc_uint8 * ch_num, 
   *ch_num = 128 + (sc_uint8)ch;
 }
 
-void _test_sc_dictionary_addr_hashes_int_to_char(sc_uint8 num, sc_uint8 mask, sc_char * ch)
-{
-  *ch = (sc_char)(num - 128);
-}
-
 TEST_F(ScDictionaryTest, smoke)
 {
   sc_dictionary * dictionary = nullptr;
   EXPECT_TRUE(sc_dictionary_initialize(
       &dictionary,
       _test_sc_dictionary_addr_hashes_children_size(),
-      _test_sc_dictionary_addr_hashes_char_to_int,
-      _test_sc_dictionary_addr_hashes_int_to_char));
+      _test_sc_dictionary_addr_hashes_char_to_int));
 
   sc_addr addr1 = sc_memory_link_new(m_ctx->GetRealContext());
   sc_char const * str1 = "concept_set1";

--- a/sc-memory/tests/sc-memory/containers/sc-dictionary.cpp
+++ b/sc-memory/tests/sc-memory/containers/sc-dictionary.cpp
@@ -139,7 +139,7 @@ TEST_F(ScDictionaryTest, find_by_substr)
 
   list = sc_dictionary_get_by_substr(dictionary, "letters_big_small");
   it = sc_list_iterator(list);
-  EXPECT_FALSE(sc_iterator_next(it));
+  EXPECT_TRUE(sc_iterator_next(it));
   sc_iterator_destroy(it);
   sc_list_destroy(list);
 }

--- a/sc-memory/tests/sc-memory/containers/sc-dictionary.cpp
+++ b/sc-memory/tests/sc-memory/containers/sc-dictionary.cpp
@@ -9,10 +9,32 @@ extern "C"
 
 using ScDictionaryTest = ScMemoryTest;
 
+sc_uint8 _test_sc_dictionary_addr_hashes_children_size()
+{
+  const sc_uint8 max_sc_char = 255;
+  const sc_uint8 min_sc_char = 1;
+
+  return max_sc_char - min_sc_char + 1;
+}
+
+void _test_sc_dictionary_addr_hashes_char_to_int(sc_char ch, sc_uint8 * ch_num, sc_uint8 * mask)
+{
+  *ch_num = 128 + (sc_uint8)ch;
+}
+
+void _test_sc_dictionary_addr_hashes_int_to_char(sc_uint8 num, sc_uint8 mask, sc_char * ch)
+{
+  *ch = (sc_char)(num - 128);
+}
+
 TEST_F(ScDictionaryTest, smoke)
 {
   sc_dictionary * dictionary = nullptr;
-  EXPECT_TRUE(sc_dictionary_initialize(&dictionary));
+  EXPECT_TRUE(sc_dictionary_initialize(
+      &dictionary,
+      _test_sc_dictionary_addr_hashes_children_size(),
+      _test_sc_dictionary_addr_hashes_char_to_int,
+      _test_sc_dictionary_addr_hashes_int_to_char));
 
   sc_addr addr1 = sc_memory_link_new(m_ctx->GetRealContext());
   sc_char * str1 = "concept_set1";
@@ -65,81 +87,4 @@ TEST_F(ScDictionaryTest, smoke)
   EXPECT_FALSE(sc_dictionary_is_in(dictionary, str1));
 
   sc_dictionary_destroy(dictionary, sc_dictionary_node_destroy);
-}
-
-TEST_F(ScDictionaryTest, find_by_substr)
-{
-  sc_dictionary * dictionary = nullptr;
-  EXPECT_TRUE(sc_dictionary_initialize(&dictionary));
-
-  sc_addr addr1 = sc_memory_link_new(m_ctx->GetRealContext());
-  sc_char * str1 = "letter_big";
-  sc_dictionary_append(dictionary, str1, strlen(str1), &addr1);
-  EXPECT_TRUE(sc_dictionary_is_in(dictionary, str1));
-
-  sc_addr addr2 = sc_memory_link_new(m_ctx->GetRealContext());
-  sc_char * str2 = "letter_small";
-  sc_dictionary_append(dictionary, str2, strlen(str2), &addr2);
-  EXPECT_TRUE(sc_dictionary_is_in(dictionary, str2));
-
-  sc_addr addr3 = sc_memory_link_new(m_ctx->GetRealContext());
-  sc_char * str3 = "let_out";
-  sc_dictionary_append(dictionary, str3, strlen(str3), &addr3);
-  EXPECT_TRUE(sc_dictionary_is_in(dictionary, str3));
-
-  sc_addr addr4 = sc_memory_link_new(m_ctx->GetRealContext());
-  sc_char * str4 = "letters";
-  sc_dictionary_append(dictionary, str4, strlen(str4), &addr4);
-  EXPECT_TRUE(sc_dictionary_is_in(dictionary, str4));
-
-  sc_list * list = sc_dictionary_get_by_substr(dictionary, "let");
-  sc_iterator * it = sc_list_iterator(list);
-  while (sc_iterator_next(it))
-  {
-    auto const addr = SC_ADDR_LOCAL_TO_INT(*(sc_addr*)sc_iterator_get(it));
-    EXPECT_TRUE(SC_ADDR_LOCAL_TO_INT(addr1) == addr
-                || SC_ADDR_LOCAL_TO_INT(addr2) == addr
-                || SC_ADDR_LOCAL_TO_INT(addr3) == addr
-                || SC_ADDR_LOCAL_TO_INT(addr4) == addr);
-  }
-  sc_iterator_destroy(it);
-  sc_list_destroy(list);
-
-  list = sc_dictionary_get_by_substr(dictionary, "letter");
-  it = sc_list_iterator(list);
-  while (sc_iterator_next(it))
-  {
-    auto const addr = SC_ADDR_LOCAL_TO_INT(*(sc_addr*)sc_iterator_get(it));
-    EXPECT_TRUE(SC_ADDR_LOCAL_TO_INT(addr1) == addr
-                || SC_ADDR_LOCAL_TO_INT(addr2) == addr
-                || SC_ADDR_LOCAL_TO_INT(addr4) == addr);
-  }
-  sc_iterator_destroy(it);
-  sc_list_destroy(list);
-
-  list = sc_dictionary_get_by_substr(dictionary, "lett");
-  it = sc_list_iterator(list);
-  while (sc_iterator_next(it))
-  {
-    auto const addr = SC_ADDR_LOCAL_TO_INT(*(sc_addr*)sc_iterator_get(it));
-    EXPECT_TRUE(SC_ADDR_LOCAL_TO_INT(addr1) == addr
-                || SC_ADDR_LOCAL_TO_INT(addr2) == addr
-                || SC_ADDR_LOCAL_TO_INT(addr4) == addr);
-  }
-  sc_iterator_destroy(it);
-  sc_list_destroy(list);
-
-  list = sc_dictionary_get_by_substr(dictionary, "letters");
-  it = sc_list_iterator(list);
-  EXPECT_TRUE(sc_iterator_next(it));
-  auto const addr = SC_ADDR_LOCAL_TO_INT(*(sc_addr*)sc_iterator_get(it));
-  EXPECT_TRUE(SC_ADDR_LOCAL_TO_INT(addr4) == addr);
-  sc_iterator_destroy(it);
-  sc_list_destroy(list);
-
-  list = sc_dictionary_get_by_substr(dictionary, "letters_big_small");
-  it = sc_list_iterator(list);
-  EXPECT_TRUE(sc_iterator_next(it));
-  sc_iterator_destroy(it);
-  sc_list_destroy(list);
 }

--- a/sc-tools/sc-builder/src/scs_translator.cpp
+++ b/sc-tools/sc-builder/src/scs_translator.cpp
@@ -11,6 +11,7 @@
 
 #include "sc-memory/utils/sc_base64.hpp"
 #include "sc-memory/utils/sc_exec.hpp"
+#include "sc-core/sc-store/sc-container/sc-string/sc_string.h"
 
 #include <boost/filesystem/path.hpp>
 
@@ -59,8 +60,8 @@ public:
         std::string data = GetBinaryFileContent(fullPath);
 
         data = ScBase64::Encode(reinterpret_cast<sc_uchar const *>(data.c_str()), data.size());
-        auto * rowData = new sc_char[data.size()];
-        memcpy(rowData, data.c_str(), data.size());
+        sc_char * rowData;
+        sc_str_cpy(rowData, (sc_pointer)data.c_str(), data.size());
 
         return std::make_shared<ScStream>(rowData, data.size(), SC_STREAM_FLAG_READ);
       }

--- a/sc-tools/sc-config-utils/sc-config/sc_config.c
+++ b/sc-tools/sc-config-utils/sc-config/sc_config.c
@@ -21,7 +21,10 @@ sc_bool sc_config_initialize(sc_config ** config, sc_char const * file_path)
   GKeyFile * key_file = g_key_file_new();
 
   if (file_path == null_ptr || g_key_file_load_from_file(key_file, file_path, G_KEY_FILE_NONE, null_ptr) == SC_FALSE)
+  {
+    g_key_file_free(key_file);
     return SC_FALSE;
+  }
 
   // load all values into hash table
   *config =

--- a/sc-tools/sc-server/src/sc-server-impl/sc-memory-json/sc-memory-json-action/sc_memory_create_elements_json_action.hpp
+++ b/sc-tools/sc-server/src/sc-server-impl/sc-memory-json/sc-memory-json-action/sc_memory_create_elements_json_action.hpp
@@ -21,7 +21,7 @@ public:
 
     auto const & resolveAddr = [&responsePayload](ScMemoryJsonPayload const & json) -> ScAddr {
       ScMemoryJsonPayload const & sub = json["value"];
-      if (json["type"] == "ref")
+      if (json["type"].get<std::string>() == "ref")
         return ScAddr(responsePayload[sub.get<size_t>()].get<size_t>());
 
       return ScAddr(sub.get<size_t>());
@@ -29,7 +29,7 @@ public:
 
     for (auto & atom : requestPayload)
     {
-      std::string const & element = atom["el"];
+      std::string const & element = atom["el"].get<std::string>();
       ScType const & type = ScType(atom["type"].get<size_t>());
 
       ScAddr created;
@@ -49,11 +49,11 @@ public:
 
         auto const & content = atom["content"];
         if (content.is_string())
-          link.Set(atom["content"].get<std::string>());
+          link.Set(content.get<std::string>());
         else if (content.is_number_integer())
-          link.Set(atom["content"].get<sc_int>());
+          link.Set(content.get<sc_int>());
         else if (content.is_number_float())
-          link.Set(atom["content"].get<float>());
+          link.Set(content.get<float>());
       }
 
       responsePayload.push_back(created.Hash());

--- a/sc-tools/sc-server/src/sc-server-impl/sc-memory-json/sc-memory-json-action/sc_memory_handle_keynodes_json_action.hpp
+++ b/sc-tools/sc-server/src/sc-server-impl/sc-memory-json/sc-memory-json-action/sc_memory_handle_keynodes_json_action.hpp
@@ -18,8 +18,8 @@ public:
 
     for (auto & atom : requestPayload)
     {
-      std::string const & idtf = atom["idtf"];
-      std::string const & type = atom["command"];
+      std::string const & idtf = atom["idtf"].get<std::string>();
+      std::string const & type = atom["command"].get<std::string>();
 
       ScAddr keynode;
       if (type == "find")

--- a/sc-tools/sc-server/src/sc-server-impl/sc-memory-json/sc-memory-json-action/sc_memory_handle_link_content_json_action.hpp
+++ b/sc-tools/sc-server/src/sc-server-impl/sc-memory-json/sc-memory-json-action/sc_memory_handle_link_content_json_action.hpp
@@ -30,8 +30,10 @@ public:
         responsePayload.push_back(GetContent(context, atom));
       else if (type == "find")
         responsePayload.push_back(FindLinksByContent(context, atom));
-      else if (type == "find_by_substr")
+      else if (type == "find_by_substr" || type == "find_links_by_substr")
         responsePayload.push_back(FindLinksByContentSubstring(context, atom));
+      else if (type == "find_strings_by_substr")
+        responsePayload.push_back(FindStringsBySubstring(context, atom));
     };
 
     if (requestPayload.is_array())
@@ -120,5 +122,23 @@ private:
       hashes.push_back(addr.Hash());
 
     return hashes;
+  }
+
+  std::vector<std::string> FindStringsBySubstring(ScMemoryContext * context, ScMemoryJsonPayload const & atom)
+  {
+    auto const & data = atom["data"];
+    std::vector<std::string> vector;
+    if (data.is_string())
+      vector = context->FindStringsBySubstring(data.get<std::string>());
+    else if (data.is_number_integer())
+      vector = context->FindStringsBySubstring(std::to_string(data.get<sc_int>()));
+    else if (data.is_number_float())
+    {
+      std::stringstream stream;
+      stream << data.get<float>();
+      vector = context->FindStringsBySubstring(stream.str());
+    }
+
+    return vector;
   }
 };

--- a/sc-tools/sc-server/src/sc-server-impl/sc-memory-json/sc-memory-json-action/sc_memory_handle_link_content_json_action.hpp
+++ b/sc-tools/sc-server/src/sc-server-impl/sc-memory-json/sc-memory-json-action/sc_memory_handle_link_content_json_action.hpp
@@ -22,7 +22,7 @@ public:
 
     auto const & process = [&context, &responsePayload, this](ScMemoryJsonPayload const & atom)
     {
-      std::string const & type = atom["command"];
+      std::string const & type = atom["command"].get<std::string>();
 
       if (type == "set")
         responsePayload.push_back(SetContent(context, atom));
@@ -51,7 +51,7 @@ private:
   sc_bool SetContent(ScMemoryContext * context, ScMemoryJsonPayload const & atom)
   {
     ScAddr const & linkAddr = ScAddr(atom["addr"].get<size_t>());
-    std::string const & contentType = atom["type"];
+    std::string const & contentType = atom["type"].get<std::string>();
     auto const & data = atom["data"];
 
     ScLink link{*context, linkAddr};

--- a/sc-tools/sc-server/src/sc-server-impl/sc-memory-json/sc-memory-json-action/sc_memory_handle_link_content_json_action.hpp
+++ b/sc-tools/sc-server/src/sc-server-impl/sc-memory-json/sc-memory-json-action/sc_memory_handle_link_content_json_action.hpp
@@ -33,7 +33,7 @@ public:
       else if (type == "find_by_substr" || type == "find_links_by_substr")
         responsePayload.push_back(FindLinksByContentSubstring(context, atom));
       else if (type == "find_strings_by_substr")
-        responsePayload.push_back(FindStringsBySubstring(context, atom));
+        responsePayload.push_back(FindLinksContentsByContentSubstring(context, atom));
     };
 
     if (requestPayload.is_array())
@@ -124,19 +124,19 @@ private:
     return hashes;
   }
 
-  std::vector<std::string> FindStringsBySubstring(ScMemoryContext * context, ScMemoryJsonPayload const & atom)
+  std::vector<std::string> FindLinksContentsByContentSubstring(ScMemoryContext * context, ScMemoryJsonPayload const & atom)
   {
     auto const & data = atom["data"];
     std::vector<std::string> vector;
     if (data.is_string())
-      vector = context->FindStringsBySubstring(data.get<std::string>());
+      vector = context->FindLinksContentsByContentSubstring(data.get<std::string>());
     else if (data.is_number_integer())
-      vector = context->FindStringsBySubstring(std::to_string(data.get<sc_int>()));
+      vector = context->FindLinksContentsByContentSubstring(std::to_string(data.get<sc_int>()));
     else if (data.is_number_float())
     {
       std::stringstream stream;
       stream << data.get<float>();
-      vector = context->FindStringsBySubstring(stream.str());
+      vector = context->FindLinksContentsByContentSubstring(stream.str());
     }
 
     return vector;

--- a/sc-tools/sc-server/src/sc-server-impl/sc-memory-json/sc-memory-json-action/sc_memory_make_template_json_action.hpp
+++ b/sc-tools/sc-server/src/sc-server-impl/sc-memory-json/sc-memory-json-action/sc_memory_make_template_json_action.hpp
@@ -63,7 +63,7 @@ protected:
   ScTemplate * MakeTemplate(ScMemoryJsonPayload const & triples)
   {
     auto const & convertItemToParam = [](ScMemoryJsonPayload paramItem) -> ScTemplateItemValue {
-      std::string const & paramType = paramItem["type"];
+      std::string const & paramType = paramItem["type"].get<std::string>();
       auto const & paramValue = paramItem["value"];
 
       ScTemplateItemValue param;
@@ -78,10 +78,11 @@ protected:
       }
       else
       {
+        std::string const alias = paramItem["alias"].get<std::string>();
         if (paramType == "type")
-          param = ScType(paramValue.get<size_t>()) >> paramItem["alias"];
+          param = ScType(paramValue.get<size_t>()) >> alias;
         else if (paramType == "addr")
-          param = ScAddr(paramValue.get<size_t>()) >> paramItem["alias"];
+          param = ScAddr(paramValue.get<size_t>()) >> alias;
       }
 
       return param;

--- a/sc-tools/sc-server/tests/api/units/test_base.cpp
+++ b/sc-tools/sc-server/tests/api/units/test_base.cpp
@@ -458,7 +458,7 @@ TEST_F(ScServerTest, HandleIntContent)
           {
               {"command", "set"},
               {"type", "int"},
-              {"data", 100},
+              {"data", 5226},
               {"addr", link.Hash()},
           },
           {
@@ -467,19 +467,19 @@ TEST_F(ScServerTest, HandleIntContent)
           },
           {
               {"command", "find"},
-              {"data", 100},
+              {"data", 5226},
           },
           {
               {"command", "find_by_substr"},
-              {"data", 100},
+              {"data", 5226},
           },
           {
               {"command", "find_links_by_substr"},
-              {"data", 100},
+              {"data", 5226},
           },
           {
               {"command", "find_strings_by_substr"},
-              {"data", 100},
+              {"data", 5226},
           },
       }));
   EXPECT_TRUE(client.Send(payloadString));
@@ -492,7 +492,7 @@ TEST_F(ScServerTest, HandleIntContent)
   EXPECT_TRUE(response["errors"].empty());
 
   EXPECT_TRUE(responsePayload[0].get<sc_bool>());
-  EXPECT_TRUE(responsePayload[1]["value"].get<sc_int>() == 100);
+  EXPECT_TRUE(responsePayload[1]["value"].get<sc_int>() == 5226);
   auto links = responsePayload[2].get<std::vector<size_t>>();
   EXPECT_FALSE(links.empty());
   EXPECT_TRUE(std::find(links.begin(), links.end(), link.Hash()) != links.end());
@@ -504,7 +504,7 @@ TEST_F(ScServerTest, HandleIntContent)
   EXPECT_TRUE(std::find(links.begin(), links.end(), link.Hash()) != links.end());
   auto strings = responsePayload[5].get<std::vector<std::string>>();
   EXPECT_FALSE(strings.empty());
-  EXPECT_TRUE(std::find(strings.begin(), strings.end(), "100") != strings.end());
+  EXPECT_TRUE(std::find(strings.begin(), strings.end(), "5226") != strings.end());
 
   client.Stop();
 }

--- a/sc-tools/sc-server/tests/api/units/test_base.cpp
+++ b/sc-tools/sc-server/tests/api/units/test_base.cpp
@@ -373,6 +373,14 @@ TEST_F(ScServerTest, HandleContent)
               {"command", "find_by_substr"},
               {"data", "some"},
           },
+          {
+              {"command", "find_links_by_substr"},
+              {"data", "some"},
+          },
+          {
+              {"command", "find_strings_by_substr"},
+              {"data", "some"},
+          },
       }));
   EXPECT_TRUE(client.Send(payloadString));
 
@@ -391,6 +399,12 @@ TEST_F(ScServerTest, HandleContent)
   links = responsePayload[3].get<std::vector<size_t>>();
   EXPECT_FALSE(links.empty());
   EXPECT_TRUE(std::find(links.begin(), links.end(), link.Hash()) != links.end());
+  links = responsePayload[4].get<std::vector<size_t>>();
+  EXPECT_FALSE(links.empty());
+  EXPECT_TRUE(std::find(links.begin(), links.end(), link.Hash()) != links.end());
+  auto strings = responsePayload[5].get<std::vector<std::string>>();
+  EXPECT_FALSE(strings.empty());
+  EXPECT_TRUE(std::find(strings.begin(), strings.end(), "some content") != strings.end());
 
   client.Stop();
 }
@@ -459,6 +473,14 @@ TEST_F(ScServerTest, HandleIntContent)
               {"command", "find_by_substr"},
               {"data", 100},
           },
+          {
+              {"command", "find_links_by_substr"},
+              {"data", 100},
+          },
+          {
+              {"command", "find_strings_by_substr"},
+              {"data", 100},
+          },
       }));
   EXPECT_TRUE(client.Send(payloadString));
 
@@ -477,6 +499,12 @@ TEST_F(ScServerTest, HandleIntContent)
   links = responsePayload[3].get<std::vector<size_t>>();
   EXPECT_FALSE(links.empty());
   EXPECT_TRUE(std::find(links.begin(), links.end(), link.Hash()) != links.end());
+  links = responsePayload[4].get<std::vector<size_t>>();
+  EXPECT_FALSE(links.empty());
+  EXPECT_TRUE(std::find(links.begin(), links.end(), link.Hash()) != links.end());
+  auto strings = responsePayload[5].get<std::vector<std::string>>();
+  EXPECT_FALSE(strings.empty());
+  EXPECT_TRUE(std::find(strings.begin(), strings.end(), "100") != strings.end());
 
   client.Stop();
 }
@@ -511,6 +539,14 @@ TEST_F(ScServerTest, HandleFloatContent)
               {"command", "find_by_substr"},
               {"data", 10.53f},
           },
+          {
+              {"command", "find_links_by_substr"},
+              {"data", 10.53f},
+          },
+          {
+              {"command", "find_strings_by_substr"},
+              {"data", 10.53f},
+          },
       }));
   EXPECT_TRUE(client.Send(payloadString));
 
@@ -529,6 +565,12 @@ TEST_F(ScServerTest, HandleFloatContent)
   links = responsePayload[3].get<std::vector<size_t>>();
   EXPECT_FALSE(links.empty());
   EXPECT_TRUE(std::find(links.begin(), links.end(), link.Hash()) != links.end());
+  links = responsePayload[4].get<std::vector<size_t>>();
+  EXPECT_FALSE(links.empty());
+  EXPECT_TRUE(std::find(links.begin(), links.end(), link.Hash()) != links.end());
+  auto strings = responsePayload[5].get<std::vector<std::string>>();
+  EXPECT_FALSE(links.empty());
+  EXPECT_TRUE(std::find(strings.begin(), strings.end(), "10.53") != strings.end());
 
   client.Stop();
 }


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/dev/pr.md/)

Features:
- Search links by substring instead of search links by prefix substring;
- Search strings by substring (to use in sc-web, for example);
- Initialize only 10 children for node in strings dictionary;
- Not violate backward compatibality;
- Standard fs-storage API namings;
- Implement sc-link content removing.