### PR TITLE
[scs] Vectors representation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Oriented sets representation (<a, ..., b>) in SCs
 
 ## [0.7.0-Rebirth] - 12.10.2022
 

--- a/sc-memory/sc-memory/scs/scs.g4
+++ b/sc-memory/sc-memory/scs/scs.g4
@@ -222,7 +222,8 @@ idtf_edge returns [ElementHandle handle]
   ;
   
 idtf_set returns [ElementHandle handle]
-  : '{' 
+  locals [ElementHandle prevEdge]
+  : sb=('{' | '<')
       { 
         std::string const setIdtf = "..set_" + std::to_string($ctx->start->getLine()) + "_" + std::to_string($ctx->start->getCharPositionInLine());
         $ctx->handle = m_parser->ProcessIdentifier(setIdtf);
@@ -240,6 +241,15 @@ idtf_set returns [ElementHandle handle]
         {
           APPEND_ATTRS($ctx->a1->items, edge);
         }
+
+        if ($ctx->sb->getText() == "<")
+        {
+          ElementHandle const relEdge = m_parser->ProcessConnector("->");
+          ElementHandle const rel = m_parser->ProcessIdentifier("rrel_1");
+          m_parser->ProcessTriple(rel, relEdge, edge);
+
+          $ctx->prevEdge = edge;
+        }
       }
       internal_sentence_list[$ctx->i1->handle]?
 
@@ -253,10 +263,22 @@ idtf_set returns [ElementHandle handle]
           {
             APPEND_ATTRS($ctx->a2->items, edge);
           }
+
+          if ($ctx->sb->getText() == "<")
+          {
+            ElementHandle const seqEdge = m_parser->ProcessConnector("=>");
+            m_parser->ProcessTriple($ctx->prevEdge, seqEdge, edge);
+
+            ElementHandle const relEdge = m_parser->ProcessConnector("->");
+            ElementHandle const rel = m_parser->ProcessIdentifier("nrel_basic_sequence");
+            m_parser->ProcessTriple(rel, relEdge, seqEdge);
+
+            $ctx->prevEdge = edge;
+          }
         }
         internal_sentence_list[$ctx->i2->handle]?
       )*
-    '}'
+    se=('}' | '>')
   ;
 
 idtf_atomic returns [ElementHandle handle]

--- a/sc-memory/tests/scs/units/test_scs_level_4.cpp
+++ b/sc-memory/tests/scs/units/test_scs_level_4.cpp
@@ -94,7 +94,7 @@ TEST(scs_level_4, simple_2)
 
 TEST(scs_level_4, vector_simple_1)
 {
-  char const * data = "set1 -> <el1; el2>;;";
+  char const * data = "set1 -> <_el1; el2>;;";
 
   scs::Parser parser;
   EXPECT_TRUE(parser.Parse(data));
@@ -104,7 +104,7 @@ TEST(scs_level_4, vector_simple_1)
       {
           { ScType::NodeConstTuple, scs::Visibility::Local },
           { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
-          { ScType::NodeConst, "el1" },
+          { ScType::NodeVar, "_el1" },
       },
       {
           { ScType::NodeConst, "rrel_1" },
@@ -138,5 +138,132 @@ TEST(scs_level_4, vector_simple_1)
   EXPECT_EQ(triples.size(), 6u);
 
   EXPECT_EQ(triples[1].m_target, triples[0].m_edge);
+  EXPECT_EQ(triples[3].m_source, triples[0].m_edge);
   EXPECT_EQ(triples[3].m_target, triples[2].m_edge);
+  EXPECT_EQ(triples[4].m_target, triples[3].m_edge);
+  EXPECT_EQ(triples[5].m_target, triples[0].m_source);
+}
+
+TEST(scs_level_4, vector_simple_2)
+{
+  char const * data = "set1 -> <_el1>;;";
+
+  scs::Parser parser;
+  EXPECT_TRUE(parser.Parse(data));
+
+  TripleTester tester(parser);
+  tester({
+      {
+          { ScType::NodeConstTuple, scs::Visibility::Local },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::NodeVar, "_el1" },
+      },
+      {
+          { ScType::NodeConst, "rrel_1" },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local }
+      },
+      {
+          { ScType::NodeConst, "set1" },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::NodeConstTuple, scs::Visibility::Local }
+      },
+  });
+
+  auto const & triples = parser.GetParsedTriples();
+
+  EXPECT_EQ(triples.size(), 3u);
+
+  EXPECT_EQ(triples[1].m_target, triples[0].m_edge);
+  EXPECT_EQ(triples[2].m_target, triples[0].m_source);
+}
+
+TEST(scs_level_4, vector_simple_3)
+{
+  char const * data = "set1 -> <>;;";
+
+  scs::Parser parser;
+  EXPECT_FALSE(parser.Parse(data));
+}
+
+TEST(scs_level_4, vector_4)
+{
+  char const * data = "set1 -> <<_el1; el3>; el2>;;";
+
+  scs::Parser parser;
+  EXPECT_TRUE(parser.Parse(data));
+
+  TripleTester tester(parser);
+  tester({
+      {
+          { ScType::NodeConstTuple, scs::Visibility::Local },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::NodeVar, "_el1" },
+      },
+      {
+          { ScType::NodeConst, "rrel_1" },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local }
+      },
+      {
+          { ScType::NodeConstTuple, scs::Visibility::Local },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::NodeConst, "el3" },
+      },
+      {
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::EdgeDCommonConst, scs::Visibility::Local },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local }
+      },
+      {
+          { ScType::NodeConst, "nrel_basic_sequence" },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::EdgeDCommonConst, scs::Visibility::Local }
+      },
+      {
+          { ScType::NodeConstTuple, scs::Visibility::Local },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::NodeConstTuple, scs::Visibility::Local }
+      },
+      {
+          { ScType::NodeConst, "rrel_1" },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local }
+      },
+      {
+          { ScType::NodeConstTuple, scs::Visibility::Local },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::NodeConst, "el2" },
+      },
+      {
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::EdgeDCommonConst, scs::Visibility::Local },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local }
+      },
+      {
+          { ScType::NodeConst, "nrel_basic_sequence" },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::EdgeDCommonConst, scs::Visibility::Local }
+      },
+      {
+          { ScType::NodeConst, "set1" },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::NodeConstTuple, scs::Visibility::Local }
+      },
+  });
+
+  auto const & triples = parser.GetParsedTriples();
+
+  EXPECT_EQ(triples.size(), 11u);
+
+  EXPECT_EQ(triples[1].m_target, triples[0].m_edge);
+  EXPECT_EQ(triples[3].m_source, triples[0].m_edge);
+  EXPECT_EQ(triples[3].m_target, triples[2].m_edge);
+  EXPECT_EQ(triples[4].m_target, triples[3].m_edge);
+  EXPECT_EQ(triples[5].m_target, triples[0].m_source);
+  EXPECT_EQ(triples[6].m_target, triples[5].m_edge);
+  EXPECT_EQ(triples[8].m_source, triples[5].m_edge);
+  EXPECT_EQ(triples[8].m_target, triples[7].m_edge);
+  EXPECT_EQ(triples[9].m_target, triples[8].m_edge);
+  EXPECT_EQ(triples[10].m_target, triples[5].m_source);
 }

--- a/sc-memory/tests/scs/units/test_scs_level_4.cpp
+++ b/sc-memory/tests/scs/units/test_scs_level_4.cpp
@@ -91,3 +91,52 @@ TEST(scs_level_4, simple_2)
   EXPECT_EQ(triples[2].m_edge, triples[3].m_target);
   EXPECT_EQ(triples[2].m_edge, triples[4].m_target);
 }
+
+TEST(scs_level_4, vector_simple_1)
+{
+  char const * data = "set1 -> <el1; el2>;;";
+
+  scs::Parser parser;
+  EXPECT_TRUE(parser.Parse(data));
+
+  TripleTester tester(parser);
+  tester({
+      {
+          { ScType::NodeConstTuple, scs::Visibility::Local },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::NodeConst, "el1" },
+      },
+      {
+          { ScType::NodeConst, "rrel_1" },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local }
+      },
+      {
+          { ScType::NodeConstTuple, scs::Visibility::Local },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::NodeConst, "el2" },
+      },
+      {
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::EdgeDCommonConst, scs::Visibility::Local },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local }
+      },
+      {
+          { ScType::NodeConst, "nrel_basic_sequence" },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::EdgeDCommonConst, scs::Visibility::Local }
+      },
+      {
+          { ScType::NodeConst, "set1" },
+          { ScType::EdgeAccessConstPosPerm, scs::Visibility::Local },
+          { ScType::NodeConstTuple, scs::Visibility::Local }
+      },
+  });
+
+  auto const & triples = parser.GetParsedTriples();
+
+  EXPECT_EQ(triples.size(), 6u);
+
+  EXPECT_EQ(triples[1].m_target, triples[0].m_edge);
+  EXPECT_EQ(triples[3].m_target, triples[2].m_edge);
+}


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/dev/pr.md/)
* [x] Update changelog
* [x] Update documentation

Now you can represent oriented sets in SCs in this form: `<a, b, c>`.