### PR TITLE
Generalize docker entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       # Use the commented env variable if you need to rebuild KB every startup.
       #- "REBUILD_KB=1"
       - "KB_PATH=/kb/repo.path"
+      - "BINARY_PATH=/sc-machine/bin"
+      - "CONFIG_PATH=/sc-machine/config/sc-machine.ini"
     command:
       - "serve"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Generalized docker_entrypoint.sh, this script can be used by external projects now
 - Now in tests all agents works in single thread
 - Replace asserts in sc-template search and gen API by exceptions throwing
 - `ScsLoader::loadScsFile` return bool instead void

--- a/scripts/build_kb.py
+++ b/scripts/build_kb.py
@@ -82,7 +82,7 @@ def copy_kb(output_path: str):
 
 
 def parse_config(path: str) -> dict:
-    config_dict = {REPO_FILE: '', OUTPUT_PATH: '', LOGFILE_PATH: '', OSTIS_PATH: abspath(join(os.path.dirname(os.path.realpath(__file__)), "../bin"))}
+    config_dict = {REPO_FILE: '', OUTPUT_PATH: '', LOGFILE_PATH: '', OSTIS_PATH: abspath(join(os.path.dirname(os.path.realpath(path)), "/bin"))}
     config = configparser.ConfigParser()
     if path is not None:
         config.read(path)
@@ -171,7 +171,7 @@ if __name__ == '__main__':
                              "priority than flags!)")
 
     parser.add_argument('-b', '--ostis_path', dest=OSTIS_PATH,
-                        help="Path to the compiled binaries of OSTIS system (../bin used by default)")
+                        help="Path to the compiled binaries of OSTIS system (<config_dir>/bin used by default)")
 
     args = parser.parse_args()
 

--- a/scripts/docker_entrypoint.sh
+++ b/scripts/docker_entrypoint.sh
@@ -9,26 +9,26 @@ function usage() {
     cat <<USAGE
 
     Usage: 
-        $0 build [KB path]
-        $0 serve [sc-server args]
+        $0 build -b binary_path -c config_path [KB path]
+        $0 serve -b binary_path -c config_path [sc-server args]
 
     Options:
         build <PATH>:       rebuilds KB from sources (provide absolute path to the source folder or repo.path file)
-        serve <args>:       Starts sc-server. Arguments passed to this command will be redirected to sc-server binary. If no arguments were given, uses "-h 0.0.0.0 -c /sc-machine/config/sc-machine.ini" as default sc-server arguments. Add these settings yourself if you are planning to use custom arguments.
+        serve <args>:       Starts sc-server. Arguments passed to this command will be redirected to sc-server binary. If no arguments were given, uses "-h 0.0.0.0" is given as default sc-server arguments. Add these settings yourself if you are planning to use custom arguments.
 
         Setting REBUILD_KB environment variable inside the container will trigger a KB rebuild. Setting custom starting point for build_kb.py can be done using KB_PATH environment variable, "/kb" is used as a default KB_PATH.
+        CONFIG_PATH and BINARY_PATH environment variables can provide the respective settings if the use of flags is undesirable.
 
 USAGE
-    "$SCRIPTS_PATH"/../bin/sc-server --help
     exit 1
 }
 
 function rebuild_kb() {
     if [ -e "$1" ]; then
-        python3 "$SCRIPTS_PATH/build_kb.py" -c "$SCRIPTS_PATH/../config/sc-machine.ini" "$1"
-    elif [ -n "$KB_PATH" ]; then
+        python3 "$SCRIPTS_PATH/build_kb.py" -c "$CONFIG_PATH" -b "$BINARY_PATH" "$@"
+    elif [ -e "$KB_PATH" ]; then
         echo "$KB_PATH is set as a KB path by the environment variable"
-        python3 "$SCRIPTS_PATH/build_kb.py" -c "$SCRIPTS_PATH/../config/sc-machine.ini" "$KB_PATH" 
+        python3 "$SCRIPTS_PATH/build_kb.py" -c "$CONFIG_PATH" -b "$BINARY_PATH" "$KB_PATH"
     else
         echo "Invalid KB source path provided."
         exit 1
@@ -36,48 +36,87 @@ function rebuild_kb() {
 }
 
 function start_server() {
-if [ "$REBUILD_KB" -eq 1 ]; then
-    # this expands to $KB_PATH if it's non-null and expands to "/kb" otherwise.
-    rebuild_kb "${KB_PATH:-"/kb"}"
-fi
+    if [ "$REBUILD_KB" -eq 1 ]; then
+        # this expands to $KB_PATH if it's non-null and expands to "/kb" otherwise.
+        rebuild_kb "${KB_PATH:-"/kb"}"
+    fi
 
-# if arguments were provided, use them instead of the default ones.
-if [ $# -eq 0 ]; then
-    # you should provide the config file path and host settings yourself in case you want to use custom options!
-    echo "Using default arguments."
-    "$SCRIPTS_PATH"/../bin/sc-server -c "$SCRIPTS_PATH"/../config/sc-machine.ini -h 0.0.0.0
-else
-    "$SCRIPTS_PATH"/../bin/sc-server "$@"
-fi
+    # if arguments were provided, use them instead of the default ones.
+    if [ $# -eq 0 ]; then
+        # you should provide the config file path and host settings yourself in case you want to use custom options!
+        echo "Using default arguments."
+        "$BINARY_PATH"/sc-server -c "$CONFIG_PATH" -h 0.0.0.0
+    else
+        "$BINARY_PATH"/sc-server "$@"
+    fi
 }
-
 
 # parse script commands
 case $1 in
 
-    # rebuild KB in case the build command was passed
-    build)
-        rebuild_kb "$2"
-        ;;
+# rebuild KB in case the build command was passed
+build)
+    shift 1;
+    while getopts "b:c:h" opt; do
+        case $opt in
+        b)
+            BINARY_PATH=$OPTARG
+            ;;
+        c)
+            CONFIG_PATH=$OPTARG
+            ;;
+        h)
+            usage
+            ;;
+        \?)
+            echoerr "Invalid option -$OPTARG"
+            usage
+            ;;
+        esac
+    done
+    # skip arguments processed by getopts
+    shift $((OPTIND - 1))
+    rebuild_kb "$@"
+    ;;
 
-    #launch sc-server
-    serve)
-        start_server "${@:2}"
-        ;;
+#launch sc-server
+serve)
+    shift 1;
+    while getopts "b:c:h" opt; do
+        case $opt in
+        b)
+            BINARY_PATH=$OPTARG
+            ;;
+        c)
+            CONFIG_PATH=$OPTARG
+            ;;
+        h)
+            usage
+            ;;
+        \?)
+            echoerr "Invalid option -$OPTARG"
+            usage
+            ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    start_server "$@"
 
-    # show help
-    --help)
-        usage
-        ;;
-    help)
-        usage
-        ;;
-    -h)
-        usage 
-        ;;
+    ;;
 
-    # All invalid commands will invoke usage page
-    *)
-        usage
-        ;;
+# show help
+--help)
+    usage
+    ;;
+help)
+    usage
+    ;;
+-h)
+    usage
+    ;;
+
+# All invalid commands will invoke usage page
+*)
+    usage
+    ;;
 esac


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/CONTRIBUTING.md)
* [x] Update changelog
* [ ] Update documentation
This change would allow us to launch sc-server of any external project that uses sc-machine as a base. This would simplify deployment efforts for OSTIS systems. The script provides a flexible way to configure its behaviour such as which config is being used (by `CONFIG_PATH`) or whether or not the KB should be rebuilt on restart (`REBUILD_KB` env variable). 

Check out the options in the script's updated help menu.