### PR TITLE
[fs-memory] Optimize channels indexing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Configs for file memory string sections
+- Divide strings file into more small files with fixed size by requested configs
 - Configuration of docker-compose.yml using .env file
 - Script run_tests.sh
 - Tests for fs-memory

--- a/docs/other/config.md
+++ b/docs/other/config.md
@@ -3,20 +3,30 @@
 [sc-memory]
 # Maximum number of segments. By default: 65536
 max_loaded_segments = 1000
-# Maximum number of threads that can be used to access to sc-memory
+# Maximum number of threads that can be used to access to sc-memory. By default: 32
 max_threads = 32
-# Maximum number of threads that can be used in events and agents handler
+# Maximum number of threads that can be used in events and agents handler. By default: core number of device processor
 max_events_and_agents_threads = 32
 
-# Period (in seconds) to save sc-memory stat
+# Period (in seconds) to save sc-memory statistics
 save_period = 3600
-# Period (in seconds) to update sc-memory stat
+# Period (in seconds) to update sc-memory statistics
 update_period = 1800
 
 # Path to compiled knowledge base folder (kb.bin should be inside this folder)
 repo_path = /path/to/kb.bin
 # Path to sc-memory shared library extensions
 extensions_path = /path/to/sc-machine/bin/extensions
+
+# Maximum number of channels to split file memory into sections. By default: 1000
+max_strings_channels = 1000
+# Maximum file memory section size. By default: 100000
+max_strings_channel_size = 100000
+# Maximum size of strings that can be found by substring. By default: 1000
+max_searchable_string_size = 1000
+# Separators used to divide strings into tokens to find this strings by its tokens substrings. By default: " _"
+# If search by substring isn't needed, set this value to "" to increase maximum performance for strings linking and searching
+term_separators = " _" 
 
 [sc-server]
 # Sc-server socket data

--- a/sc-machine.ini
+++ b/sc-machine.ini
@@ -3,8 +3,6 @@ max_loaded_segments = 1000
 max_threads = 32
 max_events_and_agents_threads = 32
 
-max_searchable_string_size = 1000
-
 save_period = 3600
 update_period = 1800
 
@@ -17,6 +15,11 @@ log_level = Info
 
 init_memory_generated_upload = false
 init_memory_generated_structure = result_structure
+
+max_strings_channels = 1000
+max_strings_channel_size = 100000
+max_searchable_string_size = 1000
+term_separators = " _"
 
 [sc-server]
 host = 127.0.0.1

--- a/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.c
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.c
@@ -117,7 +117,8 @@ inline sc_dictionary_node * _sc_dictionary_get_next_node(
   sc_uint64 const bucket_idx = SC_DICTIONARY_GET_BUCKET_NUM(num);
   sc_uint64 const child_idx = SC_DICTIONARY_GET_CHILD_NUM(num);
 
-  return node->next == null_ptr ? null_ptr : (node->next[bucket_idx] == null_ptr ? null_ptr : node->next[bucket_idx][child_idx]);
+  return node->next == null_ptr ? null_ptr
+                                : (node->next[bucket_idx] == null_ptr ? null_ptr : node->next[bucket_idx][child_idx]);
 }
 
 sc_dictionary_node * sc_dictionary_append_to_node(sc_dictionary * dictionary, sc_char const * string, sc_uint32 size)

--- a/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.h
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.h
@@ -17,10 +17,10 @@
 typedef struct _sc_dictionary_node
 {
   struct _sc_dictionary_node *** next;  // a pointer to sc-dictionary node children pointers
-  sc_char * offset;                    // a pointer to substring of node string
-  sc_uint32 offset_size;               // size to substring of node string
-  void * data;                         // storing data
-  sc_uint8 mask;                       // mask for rights checking and memory optimization
+  sc_char * offset;                     // a pointer to substring of node string
+  sc_uint32 offset_size;                // size to substring of node string
+  void * data;                          // storing data
+  sc_uint8 mask;                        // mask for rights checking and memory optimization
 } sc_dictionary_node;
 
 //! A sc-dictionary structure node to store pairs of <string, object> type

--- a/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.h
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-dictionary/sc_dictionary.h
@@ -9,23 +9,14 @@
 
 #include "../../sc_types.h"
 
-#define SC_DC_NODE_ACCESS_LVL_RMASK 0b00000001
-#define SC_DC_NODE_ACCESS_LVL_WMASK 0b00000010
-
-#define sc_dc_node_access_lvl_make_read(node) (node->mask |= SC_DC_NODE_ACCESS_LVL_RMASK)
-#define sc_dc_node_access_lvl_make_no_read(node) (node->mask &= ~SC_DC_NODE_ACCESS_LVL_RMASK)
-#define sc_dc_node_access_lvl_check_read(node) \
-  ((node->mask & SC_DC_NODE_ACCESS_LVL_RMASK) == SC_DC_NODE_ACCESS_LVL_RMASK)
-
-#define sc_dc_node_access_lvl_make_write(node) (node->mask |= SC_DC_NODE_ACCESS_LVL_WMASK)
-#define sc_dc_node_access_lvl_make_no_write(node) (node->mask &= ~SC_DC_NODE_ACCESS_LVL_WMASK)
-#define sc_dc_node_access_lvl_check_write(node) \
-  ((node->mask & SC_DC_NODE_ACCESS_LVL_WMASK) == SC_DC_NODE_ACCESS_LVL_WMASK)
+#define sc_dc_node_access_lvl_add_mask(node_mask, mask) ((node_mask) |= (mask))
+#define sc_dc_node_access_lvl_remove_mask(node_mask, mask) ((node_mask) &= ~(mask))
+#define sc_dc_node_access_lvl_check_mask(node_mask, mask) (((node_mask) & (mask)) == (mask))
 
 //! A sc-dictionary structure node to store prefixes
 typedef struct _sc_dictionary_node
 {
-  struct _sc_dictionary_node ** next;  // a pointer to sc-dictionary node children pointers
+  struct _sc_dictionary_node *** next;  // a pointer to sc-dictionary node children pointers
   sc_char * offset;                    // a pointer to substring of node string
   sc_uint32 offset_size;               // size to substring of node string
   void * data;                         // storing data
@@ -53,16 +44,10 @@ sc_bool sc_dictionary_initialize(
 
 /*! Destroys a sc-dictionary
  * @param dictionary A sc-dictionary pointer to destroy
- * @param node_destroy A painter to sc-dictionary node destroy method that passes that node and additional args
+ * @param node_destroy A painter to sc-dictionary node destroy method that passes that node to clear it
  * @returns Returns SC_TRUE, if a sc-dictionary exists; otherwise return SC_FALSE.
  */
-sc_bool sc_dictionary_destroy(sc_dictionary * dictionary, sc_bool (*node_destroy)(sc_dictionary_node *, void **));
-
-/*! Destroys a sc-dictionary node
- * @param node A sc-dictionary node pointer to destroy
- * @param args An additional args used with node destroying
- */
-sc_bool sc_dictionary_node_destroy(sc_dictionary_node * node, void ** args);
+sc_bool sc_dictionary_destroy(sc_dictionary * dictionary, void (*node_clear)(sc_dictionary_node *));
 
 /*! Appends a string to a sc-dictionary by a common prefix with another string started in sc-dictionary node, if such
  * exists. In end sc-dictionary node stores pointer to data by string.

--- a/sc-memory/sc-core/sc-store/sc-container/sc-string/sc_string.h
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-string/sc_string.h
@@ -34,9 +34,9 @@
 #define sc_int_to_str_int(number, string, length) \
   length = (number == 0) ? 1 : snprintf(null_ptr, 0, "%llu", number); \
   string = sc_mem_new(sc_char, length + 1); \
-  gcvt(number, length, string)
+  (void)gcvt(number, length, string)
 
-#define sc_str_int_to_int(string, number) number = atoi(string);
+#define sc_str_int_to_int(string, number) number = atoi(string)
 
 #define sc_str_find(str, substring) strstr(str, substring) != null_ptr
 

--- a/sc-memory/sc-core/sc-store/sc-container/sc-string/sc_string.h
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-string/sc_string.h
@@ -31,10 +31,9 @@
 
 #define sc_str_len(string) strlen(string)
 
-#define sc_int_to_str_int(number, string, length) \
-  length = (number == 0) ? 1 : snprintf(null_ptr, 0, "%llu", number); \
-  string = sc_mem_new(sc_char, length + 1); \
-  (void)gcvt(number, length, string)
+#define sc_int_to_str_int(number, string, size) \
+  sprintf(string, "%llu", number); \
+  size = sc_str_len(string)
 
 #define sc_str_int_to_int(string, number) number = atoi(string)
 

--- a/sc-memory/sc-core/sc-store/sc-container/sc-string/sc_string.h
+++ b/sc-memory/sc-core/sc-store/sc-container/sc-string/sc_string.h
@@ -22,6 +22,11 @@
     sc_mem_cpy(copy, string, size); \
   })
 
+#define sc_str_concat(string1, string2, out_string) \
+  sc_uint32 const size = sc_str_len(string1) + sc_str_len(string2) + 1; \
+  out_string = sc_mem_new(sc_char, size + 1); \
+  sc_str_printf(out_string, size, "%s%s", string1, string2)
+
 #define sc_str_has_prefix(str, prefix) g_str_has_prefix(str, prefix)
 
 #define sc_str_len(string) strlen(string)
@@ -32,12 +37,6 @@
   gcvt(number, length, string)
 
 #define sc_str_int_to_int(string, number) number = atoi(string);
-
-#define sc_float_to_str_float(number, string) \
-  sc_ulong digit_size = snprintf(NULL, 0, "%lu", (sc_ulong)number); \
-  static sc_ulong mnemonic_size = 4; \
-  string = sc_mem_new(sc_char, digit_size + mnemonic_size + 1); \
-  gcvt(number, digit_size, string)
 
 #define sc_str_find(str, substring) strstr(str, substring) != null_ptr
 

--- a/sc-memory/sc-core/sc-store/sc-fs-memory/sc_dictionary_fs_memory.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-memory/sc_dictionary_fs_memory.c
@@ -35,7 +35,7 @@ sc_io_channel * _sc_dictionary_fs_memory_get_strings_channel_by_offset(
     return memory->strings_channels[idx];
 
   if (idx > 0 && memory->strings_channels[idx - 1] != null_ptr)
-    g_io_channel_flush(memory->strings_channels[idx - 1], null_ptr);
+    sc_io_channel_flush(memory->strings_channels[idx - 1], null_ptr);
 
   sc_char strings_channel_number[DEFAULT_STRING_INT_SIZE];
   {

--- a/sc-memory/sc-core/sc-store/sc-fs-memory/sc_dictionary_fs_memory.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-memory/sc_dictionary_fs_memory.c
@@ -23,7 +23,12 @@ sc_io_channel * _sc_dictionary_fs_memory_get_strings_channel_by_offset(
 {
   sc_uint64 const idx = strings_offset / memory->max_strings_channel_size;
   if (idx >= memory->max_strings_channels)
+  {
+    sc_fs_memory_info(
+        "Max strings channels is %llu. File memory is full. Please extends or swap file memory",
+        memory->max_strings_channels);
     return null_ptr;
+  }
 
   if (memory->strings_channels[idx] != null_ptr)
     return memory->strings_channels[idx];
@@ -490,7 +495,7 @@ sc_dictionary_fs_memory_status _sc_dictionary_fs_memory_read_string_by_offset(
     sc_char ** string)
 {
   sc_io_channel * strings_channel = _sc_dictionary_fs_memory_get_strings_channel_by_offset(memory, string_offset);
-  ;
+
   if (strings_channel == null_ptr)
   {
     sc_fs_memory_error("Path `%s` doesn't exist", "path");
@@ -1289,7 +1294,7 @@ error:
 {
   sc_iterator_destroy(data_it);
   return SC_FALSE;
-};
+}
 }
 
 sc_dictionary_fs_memory_status _sc_dictionary_fs_memory_save_term_string_offsets(sc_dictionary_fs_memory const * memory)
@@ -1370,7 +1375,7 @@ error:
 {
   sc_iterator_destroy(data_it);
   return SC_FALSE;
-};
+}
 }
 
 sc_dictionary_fs_memory_status _sc_dictionary_fs_memory_save_string_offsets_link_hashes(

--- a/sc-memory/sc-core/sc-store/sc-fs-memory/sc_dictionary_fs_memory.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-memory/sc_dictionary_fs_memory.c
@@ -41,7 +41,7 @@ sc_io_channel * _sc_dictionary_fs_memory_get_strings_channel_by_offset(
   {
     sc_uint64 strings_channel_number_size;
     sc_int_to_str_int(idx + 1, strings_channel_number, strings_channel_number_size);
-    (void) strings_channel_number_size;
+    (void)strings_channel_number_size;
   }
   static sc_char const * strings_postfix = "strings";
   sc_char * strings_channel_name;
@@ -976,9 +976,8 @@ sc_dictionary_fs_memory_status _sc_dictionary_fs_memory_get_link_hashes_by_terms
   arguments[2] = *link_hashes;
   sc_dictionary_fs_memory_status const status = sc_dictionary_visit_down_nodes(
       string_offsets_terms_dictionary, _sc_dictionary_fs_memory_get_link_hashes_by_string_offsets, arguments);
-  sc_dictionary_destroy(string_offsets_terms_dictionary, _sc_dictionary_fs_memory_node_clear)
-      ? SC_FS_MEMORY_OK
-      : SC_FS_MEMORY_READ_ERROR;
+  sc_dictionary_destroy(string_offsets_terms_dictionary, _sc_dictionary_fs_memory_node_clear) ? SC_FS_MEMORY_OK
+                                                                                              : SC_FS_MEMORY_READ_ERROR;
   return status;
 }
 

--- a/sc-memory/sc-core/sc-store/sc-fs-memory/sc_dictionary_fs_memory.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-memory/sc_dictionary_fs_memory.h
@@ -11,20 +11,25 @@
 #include "../sc_defines.h"
 #include "../sc_stream.h"
 
-#include "sc_fs_memory_status.h"
-
 #include "../sc-container/sc-dictionary/sc_dictionary.h"
 #include "../sc-container/sc-list/sc_list.h"
+
+#include "sc_fs_memory_status.h"
+#include "../../sc_memory_params.h"
 
 typedef sc_fs_memory_status sc_dictionary_fs_memory_status;
 
 typedef struct _sc_dictionary_fs_memory
 {
-  sc_char * path;                        // path to all dictionary files
-  sc_uint64 max_searchable_string_size;  // maximal size of strings that can be found by string/substring
+  sc_char * path;  // path to all dictionary files
+  sc_bool clear;
 
-  sc_char * strings_path;  // path to dictionary file with strings and its offsets
-  void * strings_channel;
+  sc_uint16 max_strings_channels;
+  sc_uint32 max_strings_channel_size;
+  sc_uint32 max_searchable_string_size;  // maximal size of strings that can be found by string/substring
+  sc_char const * term_separators;
+
+  void ** strings_channels;
   sc_uint64 last_string_offset;  // last offset of string in 'string_path`
 
   sc_char * terms_string_offsets_path;              // path to dictionary file with terms and its strings offsets
@@ -45,15 +50,12 @@ typedef struct _sc_link_hash_content
 
 /*! Initialize sc-dictionary file system memory in specified path.
  * @param memory[out] A pointer to sc-memory instance
- * @param path Path to store on file system
- * @param max_searchable_string_size Maximal size of strings that can be found by string/substring
+ * @param params Memory configure params
  * @returns SC_FS_MEMORY_OK, if file system memory initialized, or SC_FS_MEMORY_WRONG_PATH if path is not correct.
  */
 sc_dictionary_fs_memory_status sc_dictionary_fs_memory_initialize_ext(
     sc_dictionary_fs_memory ** memory,
-    sc_char const * path,
-    sc_bool clear,
-    sc_uint32 max_searchable_string_size);
+    sc_memory_params const * params);
 
 /*! Initialize sc-dictionary file system memory in specified path.
  * @param memory[out] A pointer to sc-memory instance

--- a/sc-memory/sc-core/sc-store/sc-fs-memory/sc_dictionary_fs_memory_private.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-memory/sc_dictionary_fs_memory_private.c
@@ -117,31 +117,40 @@ sc_bool _sc_dictionary_fs_memory_string_node_destroy(sc_dictionary_node * node, 
   return SC_TRUE;
 }
 
-sc_char * _sc_dictionary_fs_memory_get_first_term(sc_char const * string)
+sc_memory_params * _sc_dictionary_fs_memory_get_default_params(sc_char const * path, sc_bool clear)
 {
-  static const sc_char delim[] = " _";
+  sc_memory_params * params = sc_mem_new(sc_memory_params, 1);
+  params->repo_path = path;
+  params->clear = clear;
+  params->max_strings_channels = DEFAULT_MAX_STRINGS_CHANNELS;
+  params->max_strings_channel_size = DEFAULT_MAX_STRINGS_CHANNEL_SIZE;
+  params->max_searchable_string_size = DEFAULT_MAX_SEARCHABLE_STRING_SIZE;
+  params->term_separators = DEFAULT_TERM_SEPARATORS;
 
+  return params;
+}
+
+sc_char * _sc_dictionary_fs_memory_get_first_term(sc_char const * string, sc_char const * term_separators)
+{
   sc_uint32 const size = sc_str_len(string);
   sc_char copied_string[size + 1];
   sc_mem_cpy(copied_string, string, size);
   copied_string[size] = '\0';
 
-  sc_char * term = strtok(copied_string, delim);
+  sc_char * term = strtok(copied_string, term_separators);
   sc_char * copied_term;
   term == null_ptr ? sc_string_empty(copied_term) : sc_str_cpy(copied_term, term, sc_str_len(term));
   return copied_term;
 }
 
-sc_list * _sc_dictionary_fs_memory_get_string_terms(sc_char const * string)
+sc_list * _sc_dictionary_fs_memory_get_string_terms(sc_char const * string, sc_char const * term_separators)
 {
-  static const sc_char delim[] = " _";
-
   sc_uint32 const size = sc_str_len(string);
   sc_char copied_string[size + 1];
   sc_mem_cpy(copied_string, string, size);
   copied_string[size] = '\0';
 
-  sc_char * term = strtok(copied_string, delim);
+  sc_char * term = strtok(copied_string, term_separators);
   sc_list * terms;
   sc_list_init(&terms);
 
@@ -160,7 +169,7 @@ sc_list * _sc_dictionary_fs_memory_get_string_terms(sc_char const * string)
       sc_dictionary_append(unique_terms, term_copy, term_length, null_ptr);
     }
 
-    term = strtok(null_ptr, delim);
+    term = strtok(null_ptr, term_separators);
   }
   sc_dictionary_destroy(unique_terms, sc_dictionary_node_destroy);
 

--- a/sc-memory/sc-core/sc-store/sc-fs-memory/sc_dictionary_fs_memory_private.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-memory/sc_dictionary_fs_memory_private.h
@@ -26,11 +26,11 @@ sc_bool _sc_uchar_dictionary_initialize(sc_dictionary ** dictionary);
 
 sc_bool _sc_number_dictionary_initialize(sc_dictionary ** dictionary);
 
-sc_bool _sc_dictionary_fs_memory_node_destroy(sc_dictionary_node * node, void ** args);
+void _sc_dictionary_fs_memory_node_clear(sc_dictionary_node * node);
 
-sc_bool _sc_dictionary_fs_memory_link_node_destroy(sc_dictionary_node * node, void ** args);
+void _sc_dictionary_fs_memory_link_node_clear(sc_dictionary_node * node);
 
-sc_bool _sc_dictionary_fs_memory_string_node_destroy(sc_dictionary_node * node, void ** args);
+void _sc_dictionary_fs_memory_string_node_clear(sc_dictionary_node * node);
 
 sc_memory_params * _sc_dictionary_fs_memory_get_default_params(sc_char const * path, sc_bool clear);
 

--- a/sc-memory/sc-core/sc-store/sc-fs-memory/sc_dictionary_fs_memory_private.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-memory/sc_dictionary_fs_memory_private.h
@@ -13,7 +13,9 @@
 #include "../sc-container/sc-list/sc_list.h"
 #include "../sc-container/sc-dictionary/sc_dictionary.h"
 
-#define SC_FS_EXT ".scdb";
+#include "../../sc_memory_params.h"
+
+#define SC_FS_EXT ".scdb"
 #define INVALID_STRING_OFFSET LONG_MAX
 
 #define SC_FS_MEMORY_PREFIX "[sc-fs-memory] "
@@ -30,8 +32,10 @@ sc_bool _sc_dictionary_fs_memory_link_node_destroy(sc_dictionary_node * node, vo
 
 sc_bool _sc_dictionary_fs_memory_string_node_destroy(sc_dictionary_node * node, void ** args);
 
-sc_char * _sc_dictionary_fs_memory_get_first_term(sc_char const * string);
+sc_memory_params * _sc_dictionary_fs_memory_get_default_params(sc_char const * path, sc_bool clear);
 
-sc_list * _sc_dictionary_fs_memory_get_string_terms(sc_char const * string);
+sc_char * _sc_dictionary_fs_memory_get_first_term(sc_char const * string, sc_char const * term_separators);
+
+sc_list * _sc_dictionary_fs_memory_get_string_terms(sc_char const * string, sc_char const * term_separators);
 
 #endif

--- a/sc-memory/sc-core/sc-store/sc-fs-memory/sc_file_system.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-memory/sc_file_system.c
@@ -71,19 +71,18 @@ void sc_fs_get_file_content(sc_char const * file_path, sc_char ** content, sc_ui
   sc_stream_free(stream);
 }
 
-sc_bool sc_fs_create_if_is_not_file(sc_char const * path)
-{
-  if (sc_fs_is_file(path) == SC_FALSE)
-    return sc_fs_create_file(path);
-
-  return SC_TRUE;
-}
-
 void sc_fs_concat_path(sc_char const * path, sc_char const * postfix, sc_char ** out_path)
 {
   sc_uint32 size = sc_str_len(path) + sc_str_len(postfix) + 2;
   *out_path = sc_mem_new(sc_char, size + 1);
   sc_str_printf(*out_path, size, "%s/%s", path, postfix);
+}
+
+void sc_fs_concat_path_ext(sc_char const * path, sc_char const * postfix, sc_char const * ext, sc_char ** out_path)
+{
+  sc_uint32 size = sc_str_len(path) + sc_str_len(postfix) + sc_str_len(ext) + 2;
+  *out_path = sc_mem_new(sc_char, size + 1);
+  sc_str_printf(*out_path, size, "%s/%s%s", path, postfix, ext);
 }
 
 sc_bool sc_fs_create_directory(sc_char const * path)

--- a/sc-memory/sc-core/sc-store/sc-fs-memory/sc_file_system.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-memory/sc_file_system.h
@@ -19,7 +19,9 @@ sc_bool sc_fs_is_binary_file(sc_char const * file_path);
 
 void sc_fs_get_file_content(sc_char const * file_path, sc_char ** content, sc_uint64 * content_size);
 
-sc_bool sc_fs_create_if_is_not_file(sc_char const * path);
+void sc_fs_concat_path(sc_char const * path, sc_char const * postfix, sc_char ** out_path);
+
+void sc_fs_concat_path_ext(sc_char const * path, sc_char const * postfix, sc_char const * ext, sc_char ** out_path);
 
 sc_bool sc_fs_create_directory(const sc_char * path);
 
@@ -28,8 +30,6 @@ sc_bool sc_fs_remove_directory(const sc_char * path);
 sc_bool sc_fs_is_directory(const sc_char * path);
 
 void * sc_fs_new_tmp_write_channel(const sc_char * path, sc_char ** tmp_file_name, sc_char * prefix);
-
-void sc_fs_concat_path(sc_char const * path, sc_char const * postfix, sc_char ** out_path);
 
 sc_char * sc_fs_execute(sc_char const * command);
 

--- a/sc-memory/sc-core/sc-store/sc-fs-memory/sc_fs_memory.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-memory/sc_fs_memory.c
@@ -9,7 +9,6 @@
 #include "sc_file_system.h"
 
 #include "../sc_segment.h"
-#include "../../sc_memory_version.h"
 #include "sc_fs_memory_builder.h"
 
 #include "glib/gstdio.h"
@@ -217,7 +216,7 @@ error:
   sc_mem_free(tmp_filename);
   sc_io_channel_shutdown(segments_channel, SC_TRUE, null_ptr);
   return SC_FALSE;
-};
+}
 }
 
 sc_bool sc_fs_memory_save(sc_segment ** segments, sc_uint32 const segments_num)

--- a/sc-memory/sc-core/sc-store/sc-fs-memory/sc_fs_memory.c
+++ b/sc-memory/sc-core/sc-store/sc-fs-memory/sc_fs_memory.c
@@ -21,19 +21,19 @@
 
 sc_fs_memory_manager * manager;
 
-sc_bool sc_fs_memory_initialize(const sc_char * path, sc_uint32 const max_searchable_string_size, sc_bool clear)
+sc_bool sc_fs_memory_initialize_ext(sc_memory_params const * params)
 {
   manager = sc_fs_memory_build();
 
   static sc_char const * segments_postfix = "segments" SC_FS_EXT;
-  sc_fs_concat_path(path, segments_postfix, &manager->segments_path);
+  sc_fs_concat_path(params->repo_path, segments_postfix, &manager->segments_path);
 
   sc_fs_memory_info("Clear sc-fs-memory");
-  if (manager->initialize(&manager->fs_memory, path, clear, max_searchable_string_size) != SC_FS_MEMORY_OK)
+  if (manager->initialize(&manager->fs_memory, params) != SC_FS_MEMORY_OK)
     return SC_FALSE;
 
   // clear repository if it needs
-  if (clear == SC_TRUE)
+  if (params->clear == SC_TRUE)
   {
     sc_fs_memory_info("Clear sc-memory segments");
     if (sc_fs_remove_file(manager->segments_path) == SC_FALSE)
@@ -41,6 +41,14 @@ sc_bool sc_fs_memory_initialize(const sc_char * path, sc_uint32 const max_search
   }
 
   return SC_TRUE;
+}
+
+sc_bool sc_fs_memory_initialize(sc_char const * path, sc_bool clear)
+{
+  sc_memory_params * params = _sc_dictionary_fs_memory_get_default_params(path, clear);
+  sc_bool const status = sc_fs_memory_initialize_ext(params);
+  sc_mem_free(params);
+  return status;
 }
 
 sc_bool sc_fs_memory_shutdown()

--- a/sc-memory/sc-core/sc-store/sc-fs-memory/sc_fs_memory.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-memory/sc_fs_memory.h
@@ -13,6 +13,7 @@
 #include "../sc_defines.h"
 #include "../sc_stream.h"
 #include "../sc-container/sc-list/sc_list.h"
+#include "../../sc_memory_params.h"
 
 #ifdef SC_DICTIONARY_FS_MEMORY
 typedef struct _sc_dictionary_fs_memory sc_fs_memory;
@@ -23,8 +24,7 @@ typedef struct _sc_fs_memory_manager
   sc_fs_memory * fs_memory;  // file system memory instance
   sc_char * segments_path;   // file path to sc-memory segments
 
-  sc_fs_memory_status (
-      *initialize)(sc_fs_memory ** memory, const sc_char * path, sc_bool clear, sc_uint32 max_searchable_string_size);
+  sc_fs_memory_status (*initialize)(sc_fs_memory ** memory, sc_memory_params const * params);
   sc_fs_memory_status (*shutdown)(sc_fs_memory * memory);
   sc_fs_memory_status (*load)(sc_fs_memory * memory);
   sc_fs_memory_status (*save)(sc_fs_memory const * memory);
@@ -59,12 +59,17 @@ typedef struct _sc_fs_memory_manager
 } sc_fs_memory_manager;
 
 /*! Initialize file system memory in specified path.
+ * @param params Memory configure params
+ * @returns SC_TRUE, if file system memory initialized.
+ */
+sc_bool sc_fs_memory_initialize_ext(sc_memory_params const * params);
+
+/*! Initialize file system memory in specified path.
  * @param path Path to store on file system
- * @param max_searchable_string_size Maximal size of strings that can be found by string/substring
  * @param clear Flag to initialize empty memory
  * @returns SC_TRUE, if file system memory initialized.
  */
-sc_bool sc_fs_memory_initialize(const sc_char * path, sc_uint32 max_searchable_string_size, sc_bool clear);
+sc_bool sc_fs_memory_initialize(sc_char const * path, sc_bool clear);
 
 /*! Shutdowns file system memory.
  * @return SC_TRUE, if file system memory shutdown.

--- a/sc-memory/sc-core/sc-store/sc-fs-memory/sc_io.h
+++ b/sc-memory/sc-core/sc-store/sc-fs-memory/sc_io.h
@@ -29,6 +29,8 @@ typedef GIOChannel sc_io_channel;
 
 #define sc_io_channel_set_encoding(channel, encoding, errors) g_io_channel_set_encoding(channel, encoding, errors)
 
+#define sc_io_channel_flush(channel, errors) g_io_channel_flush(channel, errors)
+
 #define sc_io_channel_shutdown(channel, flush, errors) \
   g_io_channel_shutdown(channel, flush, errors); \
   g_io_channel_unref(channel)

--- a/sc-memory/sc-core/sc-store/sc_event.c
+++ b/sc-memory/sc-core/sc-store/sc_event.c
@@ -268,7 +268,7 @@ sc_result sc_event_notify_element_deleted(sc_addr element)
   if (events_table == null_ptr)
     goto result;
 
-  // lookup for all registered to specified sc-element events
+  // sc_set_lookup for all registered to specified sc-element events
   element_events_list = (GSList *)g_hash_table_lookup(events_table, TABLE_KEY(element));
   if (element_events_list)
   {
@@ -339,7 +339,7 @@ sc_result sc_event_emit_impl(
   if (events_table == null_ptr)
     goto result;
 
-  // lookup for all registered to specified sc-element events
+  // sc_set_lookup for all registered to specified sc-element events
   element_events_list = (GSList *)g_hash_table_lookup(events_table, TABLE_KEY(el));
 
   while (element_events_list != null_ptr)

--- a/sc-memory/sc-core/sc-store/sc_event/sc_event_queue.c
+++ b/sc-memory/sc-core/sc-store/sc_event/sc_event_queue.c
@@ -56,7 +56,7 @@ sc_event_queue * sc_event_queue_new_ext(sc_uint32 max_events_and_agents_threads)
   queue->running = SC_TRUE;
   g_mutex_init(&queue->mutex);
 
-  max_events_and_agents_threads = sc_max(1, sc_min(max_events_and_agents_threads, g_get_num_processors()));
+  max_events_and_agents_threads = sc_boundary(max_events_and_agents_threads, 1, g_get_num_processors());
   {
     sc_message("[sc-events] Configuration:");
     sc_message("\tMax events and agents threads: %d", max_events_and_agents_threads);

--- a/sc-memory/sc-core/sc-store/sc_storage.c
+++ b/sc-memory/sc-core/sc-store/sc_storage.c
@@ -149,9 +149,9 @@ result:
 
 // -----------------------------------------------------------------------------
 
-sc_bool sc_storage_initialize(const sc_memory_params * params)
+sc_bool sc_storage_initialize(sc_memory_params const * params)
 {
-  sc_bool result = sc_fs_memory_initialize(params->repo_path, params->max_searchable_string_size, params->clear);
+  sc_bool result = sc_fs_memory_initialize_ext(params);
   if (result == SC_FALSE)
     return SC_FALSE;
 

--- a/sc-memory/sc-core/sc-store/sc_types.h
+++ b/sc-memory/sc-core/sc-store/sc_types.h
@@ -39,6 +39,7 @@ typedef void * sc_pointer;
 
 #  define sc_min(a, b) ((a) < (b) ? (a) : (b))
 #  define sc_max(a, b) ((a) > (b) ? (a) : (b))
+#  define sc_boundary(x, a, b) sc_max(a, sc_min(x, b))
 
 // booleans
 #  define SC_FALSE 0

--- a/sc-memory/sc-core/sc_memory.c
+++ b/sc-memory/sc-core/sc_memory.c
@@ -15,7 +15,6 @@
 #include "sc-store/sc_types.h"
 
 #include "sc-store/sc_event/sc_event_private.h"
-#include "sc-store/sc-container/sc-dictionary/sc_dictionary.h"
 
 #include "sc-store/sc-base/sc_allocator.h"
 #include "sc-store/sc-base/sc_assert_utils.h"
@@ -34,7 +33,7 @@ sc_memory_context * sc_memory_initialize(const sc_memory_params * params)
   sc_memory_info("Initialize components");
 
   sc_memory_info("Version: %s", params->version);
-  sc_message("\tClean memory on shutdown: %s", params->clear ? "On" : "Off");
+  sc_message("\tClean on initialize: %s", params->clear ? "On" : "Off");
   sc_message("\tExtensions path: %s", params->ext_path);
   sc_message("\tSave period: %d", params->save_period);
   sc_message("\tUpdate period: %d", params->update_period);

--- a/sc-memory/sc-core/sc_memory_params.c
+++ b/sc-memory/sc-core/sc_memory_params.c
@@ -9,6 +9,7 @@
 void sc_memory_params_clear(sc_memory_params * params)
 {
   params->version = (sc_char const *)null_ptr;
+
   params->clear = SC_FALSE;
   params->repo_path = (sc_char const *)null_ptr;
   params->ext_path = (sc_char const *)null_ptr;
@@ -16,7 +17,6 @@ void sc_memory_params_clear(sc_memory_params * params)
 
   params->save_period = DEFAULT_SAVE_PERIOD;      // seconds
   params->update_period = DEFAULT_UPDATE_PERIOD;  // seconds
-  params->max_searchable_string_size = DEFAULT_MAX_SEARCHABLE_STRING_SIZE;
 
   params->log_type = DEFAULT_LOG_TYPE;
   params->log_file = DEFAULT_LOG_FILE;
@@ -28,4 +28,9 @@ void sc_memory_params_clear(sc_memory_params * params)
 
   params->init_memory_generated_structure = (sc_char const *)null_ptr;
   params->init_memory_generated_upload = SC_FALSE;
+
+  params->max_strings_channels = DEFAULT_MAX_STRINGS_CHANNELS;
+  params->max_strings_channel_size = DEFAULT_MAX_STRINGS_CHANNEL_SIZE;
+  params->max_searchable_string_size = DEFAULT_MAX_SEARCHABLE_STRING_SIZE;
+  params->term_separators = DEFAULT_TERM_SEPARATORS;
 }

--- a/sc-memory/sc-core/sc_memory_params.h
+++ b/sc-memory/sc-core/sc_memory_params.h
@@ -15,32 +15,41 @@
 #define DEFAULT_MAX_EVENTS_AND_AGENTS_THREADS 32
 #define DEFAULT_MIN_EVENTS_AND_AGENTS_THREADS 1
 #define DEFAULT_MAX_LOADED_SEGMENTS 1000
-#define DEFAULT_MAX_SEARCHABLE_STRING_SIZE 1000
 #define DEFAULT_LOG_TYPE "Console"
 #define DEFAULT_LOG_FILE ""
 #define DEFAULT_LOG_LEVEL "Info"
+#define DEFAULT_MAX_STRINGS_CHANNELS 1000
+#define DEFAULT_MAX_STRINGS_CHANNEL_SIZE 100000
+#define DEFAULT_MAX_SEARCHABLE_STRING_SIZE 1000
+#define DEFAULT_TERM_SEPARATORS " _"
 
 typedef struct _sc_memory_params
 {
-  const sc_char * version;
-  sc_bool clear;
-  const sc_char * repo_path;
-  const sc_char * ext_path;
-  const sc_char ** enabled_exts;
-  sc_uint32 save_period;
-  sc_uint32 update_period;
+  sc_char const * version;
 
-  const sc_char * log_type;
-  const sc_char * log_file;
-  const sc_char * log_level;
+  sc_bool clear;
+  sc_char const * repo_path;
+  sc_char const * ext_path;
+  sc_char const ** enabled_exts;
 
   sc_uint32 max_loaded_segments;
-  sc_uint32 max_searchable_string_size;
   sc_uint8 max_threads;
   sc_uint32 max_events_and_agents_threads;
 
-  const sc_char * init_memory_generated_structure;
+  sc_uint32 save_period;
+  sc_uint32 update_period;
+
+  sc_char const * log_type;
+  sc_char const * log_file;
+  sc_char const * log_level;
+
+  sc_char const * init_memory_generated_structure;
   sc_bool init_memory_generated_upload;
+
+  sc_uint16 max_strings_channels;
+  sc_uint32 max_strings_channel_size;
+  sc_uint32 max_searchable_string_size;
+  sc_char const * term_separators;
 } sc_memory_params;
 
 _SC_EXTERN void sc_memory_params_clear(sc_memory_params * params);

--- a/sc-memory/sc-memory/sc_struct.hpp
+++ b/sc-memory/sc-memory/sc_struct.hpp
@@ -14,8 +14,8 @@ class ScSet
 public:
   _SC_EXTERN ScSet(class ScMemoryContext & ctx, ScAddr const & setAddr);
 
-  /* Append element into sc-hash-map. If element already exist, then doesn't append it and return false; otherwise returns
-   * true. */
+  /* Append element into sc-hash-map. If element already exist, then doesn't append it and return false; otherwise
+   * returns true. */
   _SC_EXTERN bool Append(ScAddr const & elAddr);
   _SC_EXTERN bool Append(ScAddr const & elAddr, ScAddr const & attrAddr);
 

--- a/sc-memory/sc-memory/sc_struct.hpp
+++ b/sc-memory/sc-memory/sc_struct.hpp
@@ -14,7 +14,7 @@ class ScSet
 public:
   _SC_EXTERN ScSet(class ScMemoryContext & ctx, ScAddr const & setAddr);
 
-  /* Append element into sc-set. If element already exist, then doesn't append it and return false; otherwise returns
+  /* Append element into sc-hash-map. If element already exist, then doesn't append it and return false; otherwise returns
    * true. */
   _SC_EXTERN bool Append(ScAddr const & elAddr);
   _SC_EXTERN bool Append(ScAddr const & elAddr, ScAddr const & attrAddr);

--- a/sc-memory/tests/sc-memory/containers/sc-dictionary.cpp
+++ b/sc-memory/tests/sc-memory/containers/sc-dictionary.cpp
@@ -28,7 +28,7 @@ sc_bool _test_sc_uchar_dictionary_initialize(sc_dictionary ** dictionary)
 
 sc_bool _test_sc_uchar_dictionary_destroy(sc_dictionary * dictionary)
 {
-  return sc_dictionary_destroy(dictionary, sc_dictionary_node_destroy);
+  return sc_dictionary_destroy(dictionary, nullptr);
 }
 
 sc_bool _test_sc_hashes_compare(void * hash, void * other)

--- a/sc-memory/tests/sc-memory/fs-storage/sc-dictionary-fs-memory-api.cpp
+++ b/sc-memory/tests/sc-memory/fs-storage/sc-dictionary-fs-memory-api.cpp
@@ -35,7 +35,7 @@ extern "C"
 #define TEXT_EXAMPLE_2 "it is the second string"
 
 #define SC_DICTIONARY_FS_MEMORY_PATH "fs-memory"
-#define SC_DICTIONARY_FS_MEMORY_STRINGS_PATH SC_DICTIONARY_FS_MEMORY_PATH "/strings.scdb"
+#define SC_DICTIONARY_FS_MEMORY_STRINGS_PATH SC_DICTIONARY_FS_MEMORY_PATH "/strings1.scdb"
 
 TEST(ScDictionaryFSMemoryTest, sc_dictionary_fs_memory_init_shutdown)
 {

--- a/sc-memory/tests/sc-memory/fs-storage/sc-dictionary-fs-memory-api.cpp
+++ b/sc-memory/tests/sc-memory/fs-storage/sc-dictionary-fs-memory-api.cpp
@@ -1152,3 +1152,83 @@ TEST(ScDictionaryFSMemoryTest, sc_dictionary_fs_memory_unite_link_hashes_by_term
 
   EXPECT_EQ(sc_dictionary_fs_memory_shutdown(memory), SC_FS_MEMORY_OK);
 }
+
+TEST(ScDictionaryFSMemoryTest, sc_dictionary_fs_memory_mutiple_link_strings)
+{
+  sc_memory_params params;
+  params.repo_path = SC_DICTIONARY_FS_MEMORY_PATH;
+  params.clear = SC_TRUE;
+  params.max_strings_channels = DEFAULT_MAX_STRINGS_CHANNELS;
+  params.max_strings_channel_size = DEFAULT_MAX_STRINGS_CHANNEL_SIZE;
+  params.max_searchable_string_size = DEFAULT_MAX_SEARCHABLE_STRING_SIZE;
+  params.term_separators = DEFAULT_TERM_SEPARATORS;
+
+  sc_dictionary_fs_memory * memory;
+  EXPECT_EQ(sc_dictionary_fs_memory_initialize_ext(&memory, &params), SC_FS_MEMORY_OK);
+
+  {
+    sc_char const string_template[] = "This is string number %llu";
+    sc_char string[50];
+
+    sc_uint64 const STRING_COUNT = 1000;
+    for (sc_uint64 hash = 0; hash < STRING_COUNT; ++hash)
+    {
+      sprintf(string, string_template, hash);
+
+      EXPECT_EQ(sc_dictionary_fs_memory_link_string(memory, hash, string, sc_str_len(string)), SC_FS_MEMORY_OK);
+    }
+
+    sc_char * found_string;
+    sc_uint64 size;
+    for (sc_uint64 hash = 0; hash < STRING_COUNT; ++hash)
+    {
+      sprintf(string, string_template, hash);
+
+      EXPECT_EQ(sc_dictionary_fs_memory_get_string_by_link_hash(memory, hash, &found_string, &size), SC_FS_MEMORY_OK);
+      EXPECT_TRUE(sc_str_cmp(found_string, string));
+      sc_mem_free(found_string);
+    }
+  }
+
+  EXPECT_EQ(sc_dictionary_fs_memory_shutdown(memory), SC_FS_MEMORY_OK);
+}
+
+TEST(ScDictionaryFSMemoryTest, sc_dictionary_fs_memory_mutiple_link_strings_with_optimized_config)
+{
+  sc_memory_params params;
+  params.repo_path = SC_DICTIONARY_FS_MEMORY_PATH;
+  params.clear = SC_TRUE;
+  params.max_strings_channels = DEFAULT_MAX_STRINGS_CHANNELS;
+  params.max_strings_channel_size = DEFAULT_MAX_STRINGS_CHANNEL_SIZE;
+  params.max_searchable_string_size = DEFAULT_MAX_SEARCHABLE_STRING_SIZE;
+  params.term_separators = "";
+
+  sc_dictionary_fs_memory * memory;
+  EXPECT_EQ(sc_dictionary_fs_memory_initialize_ext(&memory, &params), SC_FS_MEMORY_OK);
+
+  {
+    sc_char const string_template[] = "This is string number %llu";
+    sc_char string[50];
+
+    sc_uint64 const STRING_COUNT = 1000;
+    for (sc_uint64 hash = 0; hash < STRING_COUNT; ++hash)
+    {
+      sprintf(string, string_template, hash);
+
+      EXPECT_EQ(sc_dictionary_fs_memory_link_string(memory, hash, string, sc_str_len(string)), SC_FS_MEMORY_OK);
+    }
+
+    sc_char * found_string;
+    sc_uint64 size;
+    for (sc_uint64 hash = 0; hash < STRING_COUNT; ++hash)
+    {
+      sprintf(string, string_template, hash);
+
+      EXPECT_EQ(sc_dictionary_fs_memory_get_string_by_link_hash(memory, hash, &found_string, &size), SC_FS_MEMORY_OK);
+      EXPECT_TRUE(sc_str_cmp(found_string, string));
+      sc_mem_free(found_string);
+    }
+  }
+
+  EXPECT_EQ(sc_dictionary_fs_memory_shutdown(memory), SC_FS_MEMORY_OK);
+}

--- a/sc-memory/tests/sc-memory/fs-storage/sc-fs-memory-api.cpp
+++ b/sc-memory/tests/sc-memory/fs-storage/sc-fs-memory-api.cpp
@@ -11,38 +11,37 @@ extern "C"
 
 #define SC_FS_MEMORY_PATH "fs-memory"
 #define SC_FS_MEMORY_SEGMENTS_PATH SC_FS_MEMORY_PATH "/segments.scdb"
-#define DEFAULT_MAX_SEARCHABLE_STRING_SIZE 1000
 
 TEST(ScFSMemoryTest, sc_fs_memory_initialize_shutdown)
 {
-  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, DEFAULT_MAX_SEARCHABLE_STRING_SIZE, SC_FALSE));
+  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, SC_FALSE));
   EXPECT_TRUE(sc_fs_memory_shutdown());
 
-  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, DEFAULT_MAX_SEARCHABLE_STRING_SIZE, SC_FALSE));
+  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, SC_FALSE));
   EXPECT_TRUE(sc_fs_memory_shutdown());
 }
 
 TEST(ScFSMemoryTest, sc_fs_memory_initialize_shutdown_invalid_path)
 {
-  EXPECT_FALSE(sc_fs_memory_initialize("", DEFAULT_MAX_SEARCHABLE_STRING_SIZE, SC_FALSE));
+  EXPECT_FALSE(sc_fs_memory_initialize("", SC_FALSE));
   EXPECT_FALSE(sc_fs_memory_shutdown());
 
-  EXPECT_FALSE(sc_fs_memory_initialize("", DEFAULT_MAX_SEARCHABLE_STRING_SIZE, SC_FALSE));
+  EXPECT_FALSE(sc_fs_memory_initialize("", SC_FALSE));
   EXPECT_FALSE(sc_fs_memory_shutdown());
 }
 
 TEST(ScFSMemoryTest, sc_fs_memory_initialize_shutdown_clear)
 {
-  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, DEFAULT_MAX_SEARCHABLE_STRING_SIZE, SC_TRUE));
+  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, SC_TRUE));
   EXPECT_TRUE(sc_fs_memory_shutdown());
 
-  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, DEFAULT_MAX_SEARCHABLE_STRING_SIZE, SC_TRUE));
+  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, SC_TRUE));
   EXPECT_TRUE(sc_fs_memory_shutdown());
 }
 
 TEST(ScFSMemoryTest, sc_fs_memory_save_load)
 {
-  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, DEFAULT_MAX_SEARCHABLE_STRING_SIZE, SC_TRUE));
+  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, SC_TRUE));
 
   sc_uint32 written_size = 2;
   sc_segment * segments[written_size];
@@ -67,7 +66,7 @@ TEST(ScFSMemoryTest, sc_fs_memory_save_load)
 
 TEST(ScFSMemoryTest, sc_fs_memory_save_load_save_invalid_file_read)
 {
-  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, DEFAULT_MAX_SEARCHABLE_STRING_SIZE, SC_TRUE));
+  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, SC_TRUE));
 
   sc_uint32 size = 2;
   sc_segment * segments[size];
@@ -86,7 +85,7 @@ TEST(ScFSMemoryTest, sc_fs_memory_save_load_save_invalid_file_read)
 
 TEST(ScFSMemoryTest, sc_fs_memory_save_load_save_invalid_segments_num_read)
 {
-  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, DEFAULT_MAX_SEARCHABLE_STRING_SIZE, SC_TRUE));
+  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, SC_TRUE));
 
   sc_uint32 size = 2;
   sc_segment * segments[size];
@@ -103,7 +102,7 @@ TEST(ScFSMemoryTest, sc_fs_memory_save_load_save_invalid_segments_num_read)
 
 TEST(ScFSMemoryTest, sc_fs_memory_save_load_save_invalid_segment_read)
 {
-  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, DEFAULT_MAX_SEARCHABLE_STRING_SIZE, SC_TRUE));
+  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, SC_TRUE));
 
   sc_uint32 size = 2;
   sc_segment * segments[size];
@@ -133,7 +132,7 @@ TEST(ScFSMemoryTest, sc_fs_memory_save_load_save_invalid_segment_read)
 
 TEST(ScFSMemoryTest, sc_fs_memory_save_load_save_invalid_file_write)
 {
-  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, DEFAULT_MAX_SEARCHABLE_STRING_SIZE, SC_TRUE));
+  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, SC_TRUE));
   EXPECT_TRUE(sc_fs_remove_directory(SC_FS_MEMORY_PATH));
 
   sc_uint32 size = 2;
@@ -150,7 +149,7 @@ TEST(ScFSMemoryTest, sc_fs_memory_save_load_save_invalid_file_write)
 
 TEST(ScFSMemoryTest, sc_fs_memory_save_load_save_invalid_segments_num_write)
 {
-  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, DEFAULT_MAX_SEARCHABLE_STRING_SIZE, SC_TRUE));
+  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, SC_TRUE));
 
   sc_uint32 size = 2;
   sc_segment * segments[size];
@@ -166,7 +165,7 @@ TEST(ScFSMemoryTest, sc_fs_memory_save_load_save_invalid_segments_num_write)
 
 TEST(ScFSMemoryTest, sc_fs_memory_save_load_save_invalid_segment_write)
 {
-  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, DEFAULT_MAX_SEARCHABLE_STRING_SIZE, SC_TRUE));
+  EXPECT_TRUE(sc_fs_memory_initialize(SC_FS_MEMORY_PATH, SC_TRUE));
 
   sc_uint32 size = 2;
   sc_segment * segments[size];

--- a/sc-tools/sc-builder/tests/units/test_base.cpp
+++ b/sc-tools/sc-builder/tests/units/test_base.cpp
@@ -43,10 +43,10 @@ TEST(ScBuilder, RunStop)
     }
     sc_memory_params const scMemoryParams = memoryConfig.GetParams();
 
-    EXPECT_EQ(std::stoi(scParams.at("max_loaded_segments")), scMemoryParams.max_loaded_segments);
-    EXPECT_EQ(std::stoi(scParams.at("max_threads")), scMemoryParams.max_threads);
-    EXPECT_EQ(std::stoi(scParams.at("save_period")), scMemoryParams.save_period);
-    EXPECT_EQ(std::stoi(scParams.at("update_period")), scMemoryParams.update_period);
+    EXPECT_EQ((sc_uint32)std::stoi(scParams.at("max_loaded_segments")), scMemoryParams.max_loaded_segments);
+    EXPECT_EQ((sc_uint8)std::stoi(scParams.at("max_threads")), scMemoryParams.max_threads);
+    EXPECT_EQ((sc_uint32)std::stoi(scParams.at("save_period")), scMemoryParams.save_period);
+    EXPECT_EQ((sc_uint32)std::stoi(scParams.at("update_period")), scMemoryParams.update_period);
     EXPECT_EQ(scParams.at("log_type"), scMemoryParams.log_type);
     EXPECT_EQ(scParams.at("log_file"), scMemoryParams.log_file);
     EXPECT_EQ(scParams.at("log_level"), scMemoryParams.log_level);

--- a/sc-tools/sc-config-utils/sc_memory_config.hpp
+++ b/sc-tools/sc-config-utils/sc_memory_config.hpp
@@ -83,8 +83,10 @@ public:
       ScConfigGroup group = config[m_groupName];
       for (auto const & key : *group)
       {
-        std::string const & value = group[key];
+        std::string value = group[key];
         std::stringstream stream;
+
+        value = value[0] == '\"' ? value.substr(1, value.length() - 2) : value;
 
         m_params.insert({key, value});
       }
@@ -117,6 +119,7 @@ public:
         SC_MACHINE_VERSION_MAJOR, SC_MACHINE_VERSION_MINOR, SC_MACHINE_VERSION_PATCH, SC_MACHINE_VERSION_SUFFIX};
 
     m_memoryParams.version = (sc_char const *)sc_version_string_new(&version);
+
     m_memoryParams.clear = HasKey("clear");
     m_memoryParams.repo_path = GetStringByKey("repo_path");
     m_memoryParams.ext_path = GetStringByKey("extensions_path");
@@ -126,8 +129,6 @@ public:
     m_memoryParams.max_threads = GetIntByKey("max_threads", DEFAULT_MAX_THREADS);
     m_memoryParams.max_events_and_agents_threads =
         GetIntByKey("max_events_and_agents_threads", DEFAULT_MAX_EVENTS_AND_AGENTS_THREADS);
-    m_memoryParams.max_searchable_string_size =
-        GetIntByKey("max_searchable_string_size", DEFAULT_MAX_SEARCHABLE_STRING_SIZE);
 
     m_memoryParams.save_period = GetIntByKey("save_period", DEFAULT_SAVE_PERIOD);
     m_memoryParams.update_period = GetIntByKey("update_period", DEFAULT_UPDATE_PERIOD);
@@ -138,6 +139,12 @@ public:
 
     m_memoryParams.init_memory_generated_upload = GetBoolByKey("init_memory_generated_upload");
     m_memoryParams.init_memory_generated_structure = GetStringByKey("init_memory_generated_structure");
+
+    m_memoryParams.max_strings_channels = GetIntByKey("max_strings_channels", DEFAULT_MAX_STRINGS_CHANNELS);
+    m_memoryParams.max_strings_channel_size = GetIntByKey("max_strings_channel_size", DEFAULT_MAX_STRINGS_CHANNEL_SIZE);
+    m_memoryParams.max_searchable_string_size =
+        GetIntByKey("max_searchable_string_size", DEFAULT_MAX_SEARCHABLE_STRING_SIZE);
+    m_memoryParams.term_separators = GetStringByKey("term_separators", DEFAULT_TERM_SEPARATORS);
 
     return m_memoryParams;
   }

--- a/scripts/build_kb.py
+++ b/scripts/build_kb.py
@@ -133,10 +133,8 @@ def main(args: dict):
         print("OSTIS binaries are not found. Check if the binary path exists and contains necessary files. You may have compiled the project in a non-default location (pass -b flag to override binary location) or didn't build the project successfully.")
         exit(1)
 
-    # prepared_kb will appear in the same folder as kb.bin
-    kb_to_prepare = join(conf["output_path"], "prepared_kb")
-    if isdir(kb_to_prepare):
-        shutil.rmtree(kb_to_prepare)
+    if isdir(conf["output_path"]):
+        shutil.rmtree(conf["output_path"])
 
     search_knowledge_bases(conf[REPO_FILE])
 
@@ -145,6 +143,8 @@ def main(args: dict):
         exit(1)
 
     copy_kb(conf[OUTPUT_PATH])
+
+    kb_to_prepare = join(conf["output_path"], "prepared_kb")
     prepare_kb(kb_to_prepare, conf[LOGFILE_PATH])
     exitcode = build_kb(conf[OUTPUT_PATH], kb_to_prepare, conf[OSTIS_PATH], abspath(args["config_file_path"]))
     # exit with non-null code in case sc-builder encountered an error


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/CONTRIBUTING.md)
* [x] Update changelog
* [x] Update documentation

Depending on the volume of knowledge bases and what identifiers are used in the knowledge base, loading the entire knowledge base into the current version of file memory can take a long time. This pull request allows you to flexibly configure the file memory configuration.

Also, all strings are written to several single-sized files, and not to one.
