### PR TITLE
[scripts] Remove kb.bin contents rather than the dir itself

### DIFF
--- a/scripts/build_kb.py
+++ b/scripts/build_kb.py
@@ -134,7 +134,9 @@ def main(args: dict):
         exit(1)
 
     if isdir(conf["output_path"]):
-        shutil.rmtree(conf["output_path"])
+        for entry in os.scandir(conf["output_path"]):
+            if entry.is_file(): os.remove(entry.path)
+            if entry.is_dir(): shutil.rmtree(entry.path)
 
     search_knowledge_bases(conf[REPO_FILE])
 


### PR DESCRIPTION
In our Docker images, kb.bin is often a mountpoint, deleting it can lead to unpredicted results and errors in runtime.

* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/CONTRIBUTING.md)
* [ ] Update changelog
* [ ] Update documentation
