### PR TITLE
Fix/wait agent finish time

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - List items semicolons for sc.s-contours
 - Internal sentences after sc.s-contour assignment
 - The success of finishing the action is marked first and only then that it was finished
+- Finish agent wait time
 
 ### Removed
 

--- a/sc-kpm/sc-agents-common/utils/AgentUtils.cpp
+++ b/sc-kpm/sc-agents-common/utils/AgentUtils.cpp
@@ -132,7 +132,7 @@ ScAddr AgentUtils::getActionResultIfExists(
   ScAddr actionNode = formActionNode(ms_context, actionClass, params);
 
   ScAddr result;
-  if (applyAction(ms_context, actionNode))
+  if (applyAction(ms_context, actionNode, waitTime))
     result = IteratorUtils::getAnyByOutRelation(ms_context, actionNode, CoreKeynodes::nrel_answer);
 
   return result;
@@ -146,7 +146,7 @@ ScAddr AgentUtils::getActionResultIfExists(
   SC_CHECK_PARAM(actionNode, ("Invalid action node address"));
 
   ScAddr result;
-  if (applyAction(ms_context, actionNode))
+  if (applyAction(ms_context, actionNode, waitTime))
     result = IteratorUtils::getAnyByOutRelation(ms_context, actionNode, CoreKeynodes::nrel_answer);
 
   return result;


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/CONTRIBUTING.md)
* [x] Update changelog
* [ ] Update documentation

Some time ago I've faced a weird bug while trying to use `AgentUtils::getActionResultIfExists`. The result was 30 seconds wait time, despite wait time set by me was 400ms.