### PR TITLE
[memory][storage] Revert set types in create node and link

### DIFF
--- a/sc-memory/sc-core/sc-store/sc_storage.c
+++ b/sc-memory/sc-core/sc-store/sc_storage.c
@@ -711,7 +711,7 @@ sc_addr sc_storage_node_new_ext(sc_memory_context const * ctx, sc_type type, sc_
     return addr;
   }
 
-  element->flags.type = type;
+  element->flags.type = sc_type_node | type;
   *result = SC_RESULT_OK;
   return addr;
 }
@@ -739,7 +739,7 @@ sc_addr sc_storage_link_new_ext(sc_memory_context const * ctx, sc_type type, sc_
     return addr;
   }
 
-  element->flags.type = type;
+  element->flags.type = sc_type_link | type;
   *result = SC_RESULT_OK;
   return addr;
 }


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/CONTRIBUTING.md)
* [x] Update changelog
* [ ] Update documentation

Returned it as it was. If we remove this logic, it turns out that all the nodes that are created are unknown and cannot be found later, because constant node types are specified everywhere in the iterators. You can check sc-web before this revert. I will fix this logic in another PR.
