### PR TITLE
[memory][scs][parser] Don't generate arcs from sc-element classes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -238,6 +238,7 @@ See documentation, to learn more about using new API.
 
 ### Changed
 
+- SCsParser no longer generates sc-arcs from types of sc-elements to sc-elements
 - Allow multiple instances of `ScLogger` class
 - Rename `ScLog` to `ScLogger`
 - Description of project in Readme

--- a/sc-memory/sc-memory/CMakeLists.txt
+++ b/sc-memory/sc-memory/CMakeLists.txt
@@ -59,7 +59,6 @@ add_dependencies(sc-memory
 )
 
 if(${SC_CLANG_FORMAT_CODE})
-    target_clangformat_setup(SCsParser)
     target_clangformat_setup(sc-memory)
 endif()
 

--- a/sc-memory/sc-memory/CMakeLists.txt
+++ b/sc-memory/sc-memory/CMakeLists.txt
@@ -59,6 +59,7 @@ add_dependencies(sc-memory
 )
 
 if(${SC_CLANG_FORMAT_CODE})
+    target_clangformat_setup(SCsParser)
     target_clangformat_setup(sc-memory)
 endif()
 

--- a/sc-memory/sc-memory/include/sc-memory/scs/scs_parser.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/scs/scs_parser.hpp
@@ -185,7 +185,7 @@ private:
   IdtfToParsedElementMap m_idtfToParsedElement;
   AliasHandles m_aliasHandles;
   std::unordered_set<std::string> m_elementTypeOutgoingBaseArcs;
-  std::unordered_map<std::string, ElementHandle> m_elementTypeNotOutgoingBaseArcsToElementTypes;
+  std::unordered_multimap<std::string, ElementHandle> m_elementTypeNotOutgoingBaseArcsToElementTypes;
 
   std::string m_lastError;
 

--- a/sc-memory/sc-memory/include/sc-memory/scs/scs_parser.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/scs/scs_parser.hpp
@@ -123,7 +123,7 @@ public:
   _SC_EXTERN bool Parse(std::string const & str);
   _SC_EXTERN ParsedElement const & GetParsedElement(ElementHandle const & handle) const;
   _SC_EXTERN TripleVector const & GetParsedTriples() const;
-  _SC_EXTERN void ForEachGeneratableTriple(
+  _SC_EXTERN void ForEachTripleForGeneration(
       std::function<void(ParsedElement const &, ParsedElement const &, ParsedElement const &)> const & callback) const;
   _SC_EXTERN std::string const & GetParseError() const;
   _SC_EXTERN AliasHandles const & GetAliases() const;

--- a/sc-memory/sc-memory/include/sc-memory/scs/scs_parser.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/scs/scs_parser.hpp
@@ -45,7 +45,7 @@ public:
   _SC_EXTERN ScType const & GetType() const;
 
   _SC_EXTERN Visibility GetVisibility() const;
-  _SC_EXTERN bool IsMetaElement() const;
+  _SC_EXTERN bool IsElementType() const;
 
   _SC_EXTERN std::string const & GetValue() const;
 
@@ -62,7 +62,7 @@ protected:
   bool m_isReversed : 1;    // flag used just for an connectors
   std::string m_value;      // string representation of content/link value
   bool m_isURL : 1;         // flag used to determine if ScLink value is an URL
-  bool m_isMetaElement;
+  bool m_isElementType;     // flag denoting whether the element is an sc-element, denoting the type of sc-elements
 };
 
 class ElementHandle
@@ -70,13 +70,13 @@ class ElementHandle
 public:
   _SC_EXTERN explicit ElementHandle(ElementID id);
   _SC_EXTERN ElementHandle();
-  _SC_EXTERN ElementHandle(ElementID id, Visibility visibility, bool isMetaElement = false);
+  _SC_EXTERN ElementHandle(ElementID id, Visibility visibility, bool IsElementType = false);
   _SC_EXTERN ElementHandle(ElementHandle const & other) = default;
 
   _SC_EXTERN ElementID operator*() const;
   _SC_EXTERN Visibility GetVisibility() const;
   _SC_EXTERN bool IsLocal() const;
-  _SC_EXTERN bool IsMetaElement() const;
+  _SC_EXTERN bool IsElementType() const;
   _SC_EXTERN bool IsValid() const;
   _SC_EXTERN bool operator==(ElementHandle const & other) const;
   _SC_EXTERN bool operator!=(ElementHandle const & other) const;
@@ -88,7 +88,7 @@ private:
 
   ElementID m_id;
   Visibility m_visibility;
-  bool m_isMetaElement;
+  bool m_isElementType;
 };
 
 struct ParsedTriple
@@ -123,7 +123,7 @@ public:
   _SC_EXTERN bool Parse(std::string const & str);
   _SC_EXTERN ParsedElement const & GetParsedElement(ElementHandle const & handle) const;
   _SC_EXTERN TripleVector const & GetParsedTriples() const;
-  _SC_EXTERN void ForEachParsedTriple(
+  _SC_EXTERN void ForEachGeneratableTriple(
       std::function<void(ParsedElement const &, ParsedElement const &, ParsedElement const &)> const & callback) const;
   _SC_EXTERN std::string const & GetParseError() const;
   _SC_EXTERN AliasHandles const & GetAliases() const;
@@ -140,6 +140,7 @@ public:
 protected:
   ParsedElement & GetParsedElementRef(ElementHandle const & handle);
 
+  bool IsMetaElement(ParsedElement const & element) const;
   ElementHandle ResolveAlias(std::string const & name);
   ElementHandle ProcessIdentifier(std::string const & name);
   ElementHandle ProcessIdentifierLevel1(std::string const & type, std::string const & name);
@@ -182,6 +183,7 @@ private:
   TripleVector m_parsedTriples;
   IdtfToParsedElementMap m_idtfToParsedElement;
   AliasHandles m_aliasHandles;
+  std::set<std::string> m_elementTypeArcs;
 
   std::string m_lastError;
 

--- a/sc-memory/sc-memory/include/sc-memory/scs/scs_parser.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/scs/scs_parser.hpp
@@ -16,6 +16,7 @@
 #include <map>
 #include <string>
 #include <functional>
+#include <unordered_set>
 
 namespace scs
 {
@@ -140,7 +141,7 @@ public:
 protected:
   ParsedElement & GetParsedElementRef(ElementHandle const & handle);
 
-  bool IsMetaElement(ParsedElement const & element) const;
+  bool IsElementTypeOutgoingBaseArc(ParsedElement const & element) const;
   ElementHandle ResolveAlias(std::string const & name);
   ElementHandle ProcessIdentifier(std::string const & name);
   ElementHandle ProcessIdentifierLevel1(std::string const & type, std::string const & name);
@@ -183,7 +184,8 @@ private:
   TripleVector m_parsedTriples;
   IdtfToParsedElementMap m_idtfToParsedElement;
   AliasHandles m_aliasHandles;
-  std::set<std::string> m_elementTypeArcs;
+  std::unordered_set<std::string> m_elementTypeOutgoingBaseArcs;
+  std::unordered_map<std::string, ElementHandle> m_elementTypeNotOutgoingBaseArcsToElementTypes;
 
   std::string m_lastError;
 

--- a/sc-memory/sc-memory/include/sc-memory/scs/scs_parser.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/scs/scs_parser.hpp
@@ -15,6 +15,7 @@
 #include <stack>
 #include <map>
 #include <string>
+#include <functional>
 
 namespace scs
 {
@@ -83,7 +84,7 @@ public:
   _SC_EXTERN bool operator<(ElementHandle const & other) const;
 
 private:
-  static const ElementID INVALID_ID = std::numeric_limits<ElementID>::max();
+  static ElementID const INVALID_ID = std::numeric_limits<ElementID>::max();
 
   ElementID m_id;
   Visibility m_visibility;
@@ -109,7 +110,7 @@ class Parser
   friend class scsParser;
 
   // Number of parsed elements, to preallocate container
-  static const size_t PARSED_PREALLOC_NUM = 1024;
+  static size_t const PARSED_PREALLOC_NUM = 1024;
 
 public:
   using TripleVector = std::vector<ParsedTriple>;
@@ -122,6 +123,8 @@ public:
   _SC_EXTERN bool Parse(std::string const & str);
   _SC_EXTERN ParsedElement const & GetParsedElement(ElementHandle const & handle) const;
   _SC_EXTERN TripleVector const & GetParsedTriples() const;
+  _SC_EXTERN void ForEachParsedTriple(
+      std::function<void(ParsedElement const &, ParsedElement const &, ParsedElement const &)> const & callback) const;
   _SC_EXTERN std::string const & GetParseError() const;
   _SC_EXTERN AliasHandles const & GetAliases() const;
 
@@ -129,17 +132,9 @@ public:
   void ForEachParsedElement(TFunc && fn) const
   {
     for (auto const & el : m_parsedElementsLocal)
-    {
-      if (el.IsMetaElement())
-        continue;
       fn(el);
-    }
     for (auto const & el : m_parsedElements)
-    {
-      if (el.IsMetaElement())
-        continue;
       fn(el);
-    }
   }
 
 protected:
@@ -157,7 +152,10 @@ protected:
   void ProcessContourBegin();
   void ProcessContourEnd(ElementHandle const & contourHandle);
 
-  void ProcessTriple(ElementHandle const & sourceHandle, ElementHandle const & connectorHandle, ElementHandle const & targetHandle);
+  void ProcessTriple(
+      ElementHandle const & sourceHandle,
+      ElementHandle const & connectorHandle,
+      ElementHandle const & targetHandle);
   void ProcessAssign(std::string const & alias, ElementHandle const & value);
 
 private:

--- a/sc-memory/sc-memory/include/sc-memory/scs/scs_parser.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/scs/scs_parser.hpp
@@ -185,7 +185,7 @@ private:
   IdtfToParsedElementMap m_idtfToParsedElement;
   AliasHandles m_aliasHandles;
   std::unordered_set<std::string> m_elementTypeOutgoingBaseArcs;
-  std::unordered_multimap<std::string, ElementHandle> m_elementTypeNotOutgoingBaseArcsToElementTypes;
+  std::multimap<std::string, ElementHandle> m_elementTypeNotOutgoingBaseArcsToElementTypes;
 
   std::string m_lastError;
 

--- a/sc-memory/sc-memory/include/sc-memory/scs/scs_types.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/scs/scs_types.hpp
@@ -22,12 +22,12 @@ public:
   static std::string GetSCsElementKeynode(ScType const & type);
 
   static ScType const & GetConnectorType(std::string const & connectorAlias);
-  static ScType const & GetKeynodeType(std::string const & keynodeAlias);
+  static ScType const & GetElementType(std::string const & keynodeAlias);
 
   static bool IsConnectorReversed(std::string const & connectorAlias);
   static bool IsConst(std::string const & idtf);
   static bool IsConnectorAttrConst(std::string const & attr);
-  static bool IsKeynodeType(std::string const & alias);
+  static bool IsElementType(std::string const & alias);
   static bool IsUnnamed(std::string const & alias);
 
 protected:

--- a/sc-memory/sc-memory/src/sc_scs_helper.cpp
+++ b/sc-memory/sc-memory/src/sc_scs_helper.cpp
@@ -163,6 +163,10 @@ private:
         {
           if (type.IsLink())
           {
+            // TODO(NikitaZotov): Throw exception if this sc-link is a sc-link with system identifier of sc-element
+            // denoting sc-elements type, and type of sc-element, for which this sc-link is specified as a system
+            // identifier, can't be extended to ScType::ConstNodeClass. See
+            // SCsHelperTest.GenerateBySCs_ContourWithExplicitlySpecifiedElementTypeSystemIdentifier.
             resultAddr = m_ctx.GenerateLink(type);
             SetupLinkContent(resultAddr, el);
           }

--- a/sc-memory/sc-memory/src/sc_scs_helper.cpp
+++ b/sc-memory/sc-memory/src/sc_scs_helper.cpp
@@ -44,7 +44,7 @@ protected:
 
     // generate triples
     std::unordered_set<std::string> typeArcsCache;
-    parser.ForEachParsedTriple(
+    parser.ForEachGeneratableTriple(
         [&](scs::ParsedElement const & source,
             scs::ParsedElement const & connector,
             scs::ParsedElement const & target) -> void
@@ -239,7 +239,8 @@ private:
     {
       // check if it's a number format
       std::regex const rNumber(
-          "^\\^\"(int8|int16|int32|int64|uint8|uint16|uint32|uint64|float|double)\\s*:\\s*([0-9]+|[0-9]+[.][0-9]+)\"$");
+          "^\\^\"(int8|int16|int32|int64|uint8|uint16|uint32|uint64|float|double)\\s*:\\s*([0-9]+|[0-9]+[.][0-9]+)"
+          "\"$");
       std::smatch result;
       if (std::regex_match(el.GetValue(), result, rNumber))
       {
@@ -296,6 +297,7 @@ private:
 SCsHelper::SCsHelper(ScMemoryContext & ctx, SCsFileInterfacePtr fileInterface)
   : m_ctx(ctx)
   , m_fileInterface(std::move(fileInterface))
+
 {
 }
 

--- a/sc-memory/sc-memory/src/sc_scs_helper.cpp
+++ b/sc-memory/sc-memory/src/sc_scs_helper.cpp
@@ -44,7 +44,7 @@ protected:
 
     // generate triples
     std::unordered_set<std::string> typeArcsCache;
-    parser.ForEachGeneratableTriple(
+    parser.ForEachTripleForGeneration(
         [&](scs::ParsedElement const & source,
             scs::ParsedElement const & connector,
             scs::ParsedElement const & target) -> void

--- a/sc-memory/sc-memory/src/sc_template_scs.cpp
+++ b/sc-memory/sc-memory/src/sc_template_scs.cpp
@@ -62,7 +62,7 @@ protected:
       passed.insert(idtf);
     };
 
-    m_parser.ForEachParsedTriple(
+    m_parser.ForEachGeneratableTriple(
         [&](scs::ParsedElement const & source,
             scs::ParsedElement const & connector,
             scs::ParsedElement const & target) -> void

--- a/sc-memory/sc-memory/src/sc_template_scs.cpp
+++ b/sc-memory/sc-memory/src/sc_template_scs.cpp
@@ -46,17 +46,16 @@ protected:
         outValue.SetReplacement(idtf.c_str());
       else
       {
-        sc_char const * alias = (isUnnamed ? nullptr : idtf.c_str());
+        sc_char const * alias = isUnnamed ? nullptr : idtf.c_str();
         ScAddr const addr = keynodes.GetKeynode(idtf);
         if (addr.IsValid())
           outValue.SetAddr(addr, alias);
+        else if (el.GetType().IsVar())
+          outValue.SetType(el.GetType(), alias);
         else
-        {
-          if (el.GetType().IsVar())
-            outValue.SetType(el.GetType(), alias);
-          else
-            SC_THROW_EXCEPTION(utils::ExceptionInvalidState, "Can't find element " << idtf);
-        }
+          SC_THROW_EXCEPTION(
+              utils::ExceptionInvalidState,
+              "Specified element with system identifier `" << idtf << "` can't be found.");
       }
 
       passed.insert(idtf);

--- a/sc-memory/sc-memory/src/sc_template_scs.cpp
+++ b/sc-memory/sc-memory/src/sc_template_scs.cpp
@@ -61,7 +61,7 @@ protected:
       passed.insert(idtf);
     };
 
-    m_parser.ForEachGeneratableTriple(
+    m_parser.ForEachTripleForGeneration(
         [&](scs::ParsedElement const & source,
             scs::ParsedElement const & connector,
             scs::ParsedElement const & target) -> void

--- a/sc-memory/sc-memory/src/sc_template_scs.cpp
+++ b/sc-memory/sc-memory/src/sc_template_scs.cpp
@@ -36,56 +36,45 @@ protected:
     utils::ScKeynodeCache keynodes(m_ctx);
     std::unordered_set<std::string> passed;
 
-    auto const MakeTemplItem = [&passed, &keynodes](scs::ParsedElement const & el, ScTemplateItem & outValue) -> bool
+    auto const MakeTemplItem = [&passed, &keynodes](scs::ParsedElement const & el, ScTemplateItem & outValue) -> void
     {
       std::string const & idtf = el.GetIdtf();
       bool const isUnnamed = scs::TypeResolver::IsUnnamed(idtf);
       bool const isPassed = passed.find(idtf) != passed.cend();
 
       if (!isUnnamed && isPassed)
-      {
         outValue.SetReplacement(idtf.c_str());
-      }
       else
       {
         sc_char const * alias = (isUnnamed ? nullptr : idtf.c_str());
         ScAddr const addr = keynodes.GetKeynode(idtf);
         if (addr.IsValid())
-        {
           outValue.SetAddr(addr, alias);
-        }
         else
         {
           if (el.GetType().IsVar())
-          {
             outValue.SetType(el.GetType(), alias);
-          }
           else
-          {
             SC_THROW_EXCEPTION(utils::ExceptionInvalidState, "Can't find element " << idtf);
-            return false;
-          }
         }
       }
 
       passed.insert(idtf);
-
-      return true;
     };
 
-    for (scs::ParsedTriple const & t : m_parser.GetParsedTriples())
-    {
-      scs::ParsedElement const & src = m_parser.GetParsedElement(t.m_source);
-      scs::ParsedElement const & connector = m_parser.GetParsedElement(t.m_connector);
-      scs::ParsedElement const & trg = m_parser.GetParsedElement(t.m_target);
+    m_parser.ForEachParsedTriple(
+        [&](scs::ParsedElement const & source,
+            scs::ParsedElement const & connector,
+            scs::ParsedElement const & target) -> void
+        {
+          ScTemplateItem sourceItem, connectorItem, targetItem;
 
-      ScTemplateItem srcItem, connectorItem, trgItem;
+          MakeTemplItem(source, sourceItem);
+          MakeTemplItem(connector, connectorItem);
+          MakeTemplItem(target, targetItem);
 
-      if (!MakeTemplItem(src, srcItem) || !MakeTemplItem(connector, connectorItem) || !MakeTemplItem(trg, trgItem))
-        break;
-
-      templ->Triple(srcItem, connectorItem, trgItem);
-    }
+          templ->Triple(sourceItem, connectorItem, targetItem);
+        });
   }
 
 private:

--- a/sc-memory/sc-memory/src/scs/scs.g4
+++ b/sc-memory/sc-memory/src/scs/scs.g4
@@ -232,11 +232,7 @@ idtf_set_elements [std::string setType]
   locals [ElementHandle prevArc]
   : {
       std::string const setIdtf = "..set_" + std::to_string($ctx->start->getLine()) + "_" + std::to_string($ctx->start->getCharPositionInLine());
-      $ctx->handle = m_parser->ProcessIdentifier(setIdtf);
-      ElementHandle const typeArc = m_parser->ProcessConnector("->");
-      ElementHandle const typeClass = m_parser->ProcessIdentifier("sc_node_tuple");
-
-      m_parser->ProcessTriple(typeClass, typeArc, $ctx->handle);
+      $ctx->handle = m_parser->ProcessIdentifierLevel1("sc_node_tuple", setIdtf);
     }
   a1=attr_list? i1=idtf_common
     {

--- a/sc-memory/sc-memory/src/scs/scs_parser.cpp
+++ b/sc-memory/sc-memory/src/scs/scs_parser.cpp
@@ -492,12 +492,11 @@ void Parser::ProcessTriple(
                                   << "` is sc-element denoting type of sc-elements.");
       else if (ScType(targetType.BitAnd(~(ScType::Const | ScType::Var))).CanExtendTo(sourceType))
         target.m_type = newTargetType;
-      else
+      else if (!sourceType.CanExtendTo(targetType))
         SC_THROW_EXCEPTION(
             utils::ExceptionParseError,
             "Can't extend type `" << std::string(targetType) << "` using type `" << std::string(sourceType)
-                                  << "` for specified sc-element, because `" << std::string(sourceType) 
-                                  << "` is not subtype of `" << std::string(targetType) << "`.");
+                                  << "` for specified sc-element.");
 
       // TODO(NikitaZotov): Unfortunately, parser collects all sc.s-elements, and only then forms sc.s-triples based on
       // the parsed sc.s-elements. Due to this, it is difficult to handle cases when it is necessary not to generate a

--- a/sc-memory/sc-memory/src/scs/scs_parser.cpp
+++ b/sc-memory/sc-memory/src/scs/scs_parser.cpp
@@ -492,21 +492,22 @@ void Parser::ProcessTriple(
                                   << "` is sc-element denoting type of sc-elements.");
       else
       {
-        // Check that any type of target sc-element without constancy mask can be extended to type of sc-elements 
-        // represented by source sc-element.
-        ScType const & targetTypeWithoutConstancyMask = targetType.BitAnd(~(ScType::Const | ScType::Var));
-        bool canTargetTypeWithoutConstancyMaskExtendToSourceType 
-            = targetTypeWithoutConstancyMask.CanExtendTo(sourceType);
+        // Removes constancy subtype from type of target sc-element and check that type of target sc-element 
+        // without constancy subtype can be extended to type of sc-elements represented by source sc-element.
+        // It is necessary to remove the constancy subtype because all existing sc-elements denoting types of 
+        // sc-elements haven't constancy subtypes.
+        ScType const & targetTypeWithoutConstancySubtype = targetType.BitAnd(~(ScType::Const | ScType::Var));
+        bool canTargetTypeWithoutConstancySubtypeExtendToSourceType 
+            = targetTypeWithoutConstancySubtype.CanExtendTo(sourceType);
 
-        // Check that any type of source sc-element with constancy mask can be extended to type of sc-elements 
-        // represented by source sc-element with constancy mask.
-        ScType const & sourceTypeWithConstancyMask = sourceType.BitAnd(ScType::Const | ScType::Var);
-        ScType const & targetTypeWithConstancyMask = targetType.BitAnd(ScType::Const | ScType::Var);
-        bool canSourceTypeWithConstancyMaskExtendToTargetTypeWithConstancyMask =
-            sourceTypeWithConstancyMask.CanExtendTo(targetTypeWithConstancyMask);
+        // After check that constancy subtypes of source and target types are compatible for extension.
+        ScType const & sourceTypeWithConstancySubtype = sourceType.BitAnd(ScType::Const | ScType::Var);
+        ScType const & targetTypeWithConstancySubtype = targetType.BitAnd(ScType::Const | ScType::Var);
+        bool doSourceAndTargetHaveCompatibleConstancySubtypes =
+            sourceTypeWithConstancySubtype.CanExtendTo(targetTypeWithConstancySubtype) 
+            || targetTypeWithConstancySubtype.CanExtendTo(sourceTypeWithConstancySubtype);
 
-        if (canTargetTypeWithoutConstancyMaskExtendToSourceType
-            && canSourceTypeWithConstancyMaskExtendToTargetTypeWithConstancyMask)
+        if (canTargetTypeWithoutConstancySubtypeExtendToSourceType && doSourceAndTargetHaveCompatibleConstancySubtypes)
           target.m_type = newTargetType;
         else if (!sourceType.CanExtendTo(targetType))
           SC_THROW_EXCEPTION(

--- a/sc-memory/sc-memory/src/scs/scs_parser.cpp
+++ b/sc-memory/sc-memory/src/scs/scs_parser.cpp
@@ -124,14 +124,12 @@ ParsedElement::ParsedElement(
   , m_value(value)
   , m_isURL(isURL)
 {
+  m_isMetaElement = scs::TypeResolver::IsKeynodeType(m_idtf);
+
   if (!m_value.empty())
-  {
-    SC_ASSERT(m_type.IsNode() || m_type.IsLink(), ("This constructor should be used for contour/link elements"));
     m_visibility = Visibility::Local;
-  }
   else
   {
-    SC_ASSERT(!isReversed || (isReversed && type.IsConnector()), ("Trying to set isReversed flag for non connector element"));
     ResolveVisibility();
 
     // all connectors has a local visibility
@@ -148,6 +146,11 @@ std::string const & ParsedElement::GetIdtf() const
 Visibility ParsedElement::GetVisibility() const
 {
   return m_visibility;
+}
+
+bool ParsedElement::IsMetaElement() const
+{
+  return m_isMetaElement;
 }
 
 ScType const & ParsedElement::GetType() const
@@ -187,35 +190,28 @@ void ParsedElement::ResolveVisibility()
   if (m_idtf[0] == '.')
   {
     if (m_idtf.size() > 1 && m_idtf[1] == '.')
-    {
       m_visibility = Visibility::Local;
-    }
     else
-    {
       m_visibility = Visibility::Global;
-    }
   }
   else
-  {
     m_visibility = Visibility::System;
-  }
 }
 
 ElementHandle::ElementHandle(ElementID id)
-  : m_id(id)
-  , m_isLocal(false)
+  : ElementHandle(id, Visibility::Global)
 {
 }
 
 ElementHandle::ElementHandle()
-  : m_id(INVALID_ID)
-  , m_isLocal(false)
+  : ElementHandle(INVALID_ID)
 {
 }
 
-ElementHandle::ElementHandle(ElementID id, bool isLocal)
+ElementHandle::ElementHandle(ElementID id, Visibility visibility, bool isMetaElement)
   : m_id(id)
-  , m_isLocal(isLocal)
+  , m_visibility(visibility)
+  , m_isMetaElement(isMetaElement)
 {
 }
 
@@ -224,9 +220,19 @@ ElementID ElementHandle::operator*() const
   return m_id;
 }
 
+Visibility ElementHandle::GetVisibility() const
+{
+  return m_visibility;
+}
+
 bool ElementHandle::IsLocal() const
 {
-  return m_isLocal;
+  return m_visibility == Visibility::Local;
+}
+
+bool ElementHandle::IsMetaElement() const
+{
+  return m_isMetaElement;
 }
 
 bool ElementHandle::IsValid() const
@@ -236,7 +242,7 @@ bool ElementHandle::IsValid() const
 
 bool ElementHandle::operator==(ElementHandle const & other) const
 {
-  return (m_id == other.m_id) && (m_isLocal == other.m_isLocal);
+  return (m_id == other.m_id) && (m_visibility == other.m_visibility);
 }
 
 bool ElementHandle::operator!=(ElementHandle const & other) const
@@ -247,14 +253,15 @@ bool ElementHandle::operator!=(ElementHandle const & other) const
 ElementHandle & ElementHandle::operator=(ElementHandle const & other)
 {
   m_id = other.m_id;
-  m_isLocal = other.m_isLocal;
+  m_visibility = other.m_visibility;
+  m_isMetaElement = other.m_isMetaElement;
   return *this;
 }
 
 bool ElementHandle::operator<(ElementHandle const & other) const
 {
   if (m_id == other.m_id)
-    return m_isLocal < other.m_isLocal;
+    return m_visibility < other.m_visibility;
 
   return m_id < other.m_id;
 }
@@ -302,32 +309,28 @@ bool Parser::Parse(std::string const & str)
   return result;
 }
 
-ParsedElement & Parser::GetParsedElementRef(ElementHandle const & elID)
+ParsedElement & Parser::GetParsedElementRef(ElementHandle const & handle)
 {
-  auto & container = (elID.IsLocal() ? m_parsedElementsLocal : m_parsedElements);
+  ParsedElementVector & container = GetContainerByElementVisibilityRef(handle.GetVisibility());
 
-  if (*elID >= container.size())
-  {
+  if (*handle >= container.size())
     SC_THROW_EXCEPTION(
         utils::ExceptionItemNotFound,
-        std::string("ElementId{") + std::to_string(*elID) + ", " + std::to_string(elID.IsLocal()) + "}");
-  }
+        "ElementId{" << std::to_string(*handle) << ", " << (size_t)handle.GetVisibility() << "}");
 
-  return container[*elID];
+  return container[*handle];
 }
 
-ParsedElement const & Parser::GetParsedElement(ElementHandle const & elID) const
+ParsedElement const & Parser::GetParsedElement(ElementHandle const & handle) const
 {
-  auto & container = (elID.IsLocal() ? m_parsedElementsLocal : m_parsedElements);
+  ParsedElementVector const & container = GetContainerByElementVisibility(handle.GetVisibility());
 
-  if (*elID >= container.size())
-  {
+  if (*handle >= container.size())
     SC_THROW_EXCEPTION(
         utils::ExceptionItemNotFound,
-        std::string("ElementId{") + std::to_string(*elID) + ", " + std::to_string(elID.IsLocal()) + "}");
-  }
+        "ElementId{" << std::to_string(*handle) << ", " << (size_t)handle.GetVisibility() << "}");
 
-  return container[*elID];
+  return container[*handle];
 }
 
 Parser::TripleVector const & Parser::GetParsedTriples() const
@@ -365,6 +368,22 @@ std::string Parser::GenerateContourIdtf()
   return std::string("..contour_") + std::to_string(m_idtfCounter++);
 }
 
+Parser::ParsedElementVector & Parser::GetContainerByElementVisibilityRef(Visibility visibility)
+{
+  if (visibility == Visibility::Local)
+    return m_parsedElementsLocal;
+
+  return m_parsedElements;
+}
+
+Parser::ParsedElementVector const & Parser::GetContainerByElementVisibility(Visibility visibility) const
+{
+  if (visibility == Visibility::Local)
+    return m_parsedElementsLocal;
+
+  return m_parsedElements;
+}
+
 ElementHandle Parser::AppendElement(
     std::string idtf,
     ScType const & type,
@@ -372,32 +391,29 @@ ElementHandle Parser::AppendElement(
     std::string const & value /* = "" */,
     bool isURL /* = false */)
 {
-  SC_CHECK_GREAT(idtf.size(), 0, "Element identifier is empty");
   if (TypeResolver::IsUnnamed(idtf))
     idtf = GenerateNodeIdtf();
 
-  ElementHandle elId;
+  ElementHandle elementHandle;
 
   // try to find element
   auto const it = m_idtfToParsedElement.find(idtf);
-  if (it != m_idtfToParsedElement.end())
-  {
-    elId = it->second;
-  }
+  if (it != m_idtfToParsedElement.cend())
+    elementHandle = it->second;
   else
   {
     // append element
-    ParsedElement el(idtf, type, isConnectorReversed, value, isURL);
+    ParsedElement element(idtf, type, isConnectorReversed, value, isURL);
+    Visibility elementVisibility = element.GetVisibility();
 
-    bool const isLocal = (el.GetVisibility() == Visibility::Local);
-    auto & container = isLocal ? m_parsedElementsLocal : m_parsedElements;
+    ParsedElementVector & container = GetContainerByElementVisibilityRef(elementVisibility);
+    elementHandle = ElementHandle(ElementID(container.size()), elementVisibility, element.IsMetaElement());
+    container.emplace_back(std::move(element));
 
-    elId = ElementHandle(ElementID(container.size()), isLocal);
-    container.emplace_back(std::move(el));
-    m_idtfToParsedElement[idtf] = elId;
+    m_idtfToParsedElement[idtf] = elementHandle;
   }
 
-  return elId;
+  return elementHandle;
 }
 
 ElementHandle Parser::ResolveAlias(std::string const & name)
@@ -413,44 +429,55 @@ ElementHandle Parser::ProcessIdentifier(std::string const & name)
   return AppendElement(name, type);
 }
 
-ElementHandle Parser::ProcessIdentifierLevel1(std::string const & type, std::string const & name)
+ElementHandle Parser::ProcessIdentifierLevel1(std::string const & scsType, std::string const & name)
 {
-  ScType elType = scs::TypeResolver::GetKeynodeType(type);
-  elType |= scs::TypeResolver::IsConst(name) ? ScType::Const : ScType::Var;
-
-  return AppendElement(name, elType);
+  ScType type = scs::TypeResolver::GetKeynodeType(scsType);
+  type |= scs::TypeResolver::IsConst(name) ? ScType::Const : ScType::Var;
+  return AppendElement(name, type);
 }
 
-void Parser::ProcessTriple(ElementHandle const & source, ElementHandle const & connector, ElementHandle const & target)
+void Parser::ProcessTriple(
+    ElementHandle const & sourceHandle,
+    ElementHandle const & connectorHandle,
+    ElementHandle const & targetHandle)
 {
-  ParsedElement const & connectorEl = GetParsedElement(connector);
+  ParsedElement & connector = GetParsedElementRef(connectorHandle);
 
-  auto AddConnector = [this, &connectorEl](ElementHandle const & src, ElementHandle const & e, ElementHandle const & trg) {
-    ParsedElement const & srcEl = GetParsedElement(src);
-    std::string const & idtf = srcEl.GetIdtf();
-    if (connectorEl.GetType() == ScType::ConstPermPosArc && scs::TypeResolver::IsKeynodeType(idtf))
+  auto AddConnector =
+      [this, &connector](
+          ElementHandle const & sourceHdl, ElementHandle const & connectorHdl, ElementHandle const & targetHdl)
+  {
+    if (((connector.GetType() == ScType::ConstPermPosArc) || (connector.GetType() == ScType::ConstActualTempPosArc))
+        && sourceHdl.IsMetaElement())
     {
-      ParsedElement & targetEl = GetParsedElementRef(trg);
-      ScType const newType = targetEl.m_type | scs::TypeResolver::GetKeynodeType(idtf);
+      ParsedElement const & source = GetParsedElement(sourceHdl);
+      ParsedElement & target = GetParsedElementRef(targetHdl);
 
-      if (targetEl.m_type.CanExtendTo(newType))
-        targetEl.m_type = newType;
+      std::string const & sourceIdtf = source.GetIdtf();
+      ScType const newType = target.m_type | scs::TypeResolver::GetKeynodeType(sourceIdtf);
+
+      if (target.m_type.CanExtendTo(newType))
+        target.m_type = newType;
       else
-        SC_THROW_EXCEPTION(utils::ExceptionParseError, "Can't merge types for element " + targetEl.GetIdtf());
+        SC_THROW_EXCEPTION(
+            utils::ExceptionParseError,
+            "Can't extend type `" << std::string(target.m_type) << "` to type `" << std::string(newType)
+                                  << "` for element `" << target.GetIdtf() << "`.");
 
-      if (!m_contourTriplesStack.empty())
-        m_parsedTriples.emplace_back(src, e, trg);
+      // TODO(NikitaZotov): Unfortunately, parser collects all sc.s-elements, and only then form sc.s-triples based on
+      // the parsed sc.s-elements. Due to this, it is difficult to handle cases when it is necessary not to generate a
+      // sc-arc from a type of sc-elements to sc-element. Therefore, now the parser marks this arcs after that they were
+      // parsed.
+      connector.m_isMetaElement = true;
     }
     else
-    {
-      m_parsedTriples.emplace_back(src, e, trg);
-    }
+      m_parsedTriples.emplace_back(sourceHdl, connectorHdl, targetHdl);
   };
 
-  if (connectorEl.IsReversed())
-    AddConnector(target, connector, source);
+  if (connector.IsReversed())
+    AddConnector(targetHandle, connectorHandle, sourceHandle);
   else
-    AddConnector(source, connector, target);
+    AddConnector(sourceHandle, connectorHandle, targetHandle);
 }
 
 void Parser::ProcessAssign(std::string const & alias, ElementHandle const & value)
@@ -480,7 +507,6 @@ ElementHandle Parser::ProcessContent(std::string content, bool isVar)
 {
   ScType const type = DefineLinkType(content, isVar);
   ParseLinkContent(content, type);
-
   return AppendElement(GenerateLinkIdtf(), type, false, content);
 }
 
@@ -501,7 +527,6 @@ ElementHandle Parser::ProcessFileURL(std::string fileURL)
 {
   ScType const type = DefineLinkType(fileURL, false);
   ParseLinkContent(fileURL, type);
-
   return AppendElement(GenerateLinkIdtf(), type, false, fileURL, true);
 }
 
@@ -529,10 +554,12 @@ void Parser::ProcessContourEnd(ElementHandle const & contourHandle)
 
   // append all new elements into contour
   for (size_t i = ind.first; i < last; ++i)
-    newElements.insert(ElementHandle(ElementID(i), false));
+    newElements.insert(ElementHandle(
+      ElementID(i), m_parsedElements[i].GetVisibility(), m_parsedElements[i].IsMetaElement()));
 
   for (size_t i = ind.second; i < lastLocal; ++i)
-    newElements.insert(ElementHandle(ElementID(i), true));
+    newElements.insert(ElementHandle(
+      ElementID(i), m_parsedElementsLocal[i].GetVisibility(), m_parsedElementsLocal[i].IsMetaElement()));
 
   size_t const tripleFirst = m_contourTriplesStack.top();
   m_contourTriplesStack.pop();
@@ -546,14 +573,17 @@ void Parser::ProcessContourEnd(ElementHandle const & contourHandle)
     newElements.insert(t.m_target);
   }
 
-  for (auto const & el : newElements)
+  for (auto const & elementHandle : newElements)
   {
-    ElementHandle const connector = ProcessConnector("->");
-    ProcessTriple(contourHandle, connector, el);
+    if (elementHandle.IsMetaElement())
+      continue;
+
+    ElementHandle const connectorHandle = ProcessConnector("->");
+    ProcessTriple(contourHandle, connectorHandle, elementHandle);
   }
 
-  ParsedElement & srcEl = GetParsedElementRef(contourHandle);
-  srcEl.m_type = ScType::ConstNodeStructure;
+  ParsedElement & contour = GetParsedElementRef(contourHandle);
+  contour.m_type = ScType::ConstNodeStructure;
 }
 
 }  // namespace scs

--- a/sc-memory/sc-memory/src/scs/scs_parser.cpp
+++ b/sc-memory/sc-memory/src/scs/scs_parser.cpp
@@ -487,26 +487,26 @@ void Parser::ProcessTriple(
       if (target.IsElementType() && !newTargetType.CanExtendTo(ScType::ConstNodeClass))
         SC_THROW_EXCEPTION(
             utils::ExceptionParseError,
-            "Can't extend type `" << std::string(targetType) << "` using type `" 
+            "Can't extend type `" << std::string(targetType) << "` using type `"
                                   << std::string(typeProvidedBySourceKeynode)
                                   << "` for specified sc-element, because sc-element `" << target.GetIdtf()
                                   << "` is sc-element denoting type of sc-elements.");
       else
       {
-        // Removes constancy subtype from type of target sc-element and check that type of target sc-element 
+        // Removes constancy subtype from type of target sc-element and check that type of target sc-element
         // without constancy subtype can be extended to type of sc-elements represented by source sc-element.
-        // It is necessary to remove the constancy subtype because some existing sc-elements denoting types of 
+        // It is necessary to remove the constancy subtype because some existing sc-elements denoting types of
         // sc-elements don't have constancy subtypes.
         ScType const & targetTypeWithoutConstancySubtype = targetType.BitAnd(~(ScType::Const | ScType::Var));
-        bool canTargetTypeWithoutConstancySubtypeExtendToSourceType
-            = targetTypeWithoutConstancySubtype.CanExtendTo(typeProvidedBySourceKeynode);
+        bool canTargetTypeWithoutConstancySubtypeExtendToSourceType =
+            targetTypeWithoutConstancySubtype.CanExtendTo(typeProvidedBySourceKeynode);
 
         // After check that constancy subtypes of source and target types are compatible for extension.
-        ScType const & constancyOfTypeProvidedBySourceKeynode 
-            = typeProvidedBySourceKeynode.BitAnd(ScType::Const | ScType::Var);
+        ScType const & constancyOfTypeProvidedBySourceKeynode =
+            typeProvidedBySourceKeynode.BitAnd(ScType::Const | ScType::Var);
         ScType const & targetTypeConstancy = targetType.BitAnd(ScType::Const | ScType::Var);
         bool doSourceAndTargetHaveCompatibleConstancySubtypes =
-            constancyOfTypeProvidedBySourceKeynode.CanExtendTo(targetTypeConstancy) 
+            constancyOfTypeProvidedBySourceKeynode.CanExtendTo(targetTypeConstancy)
             || targetTypeConstancy.CanExtendTo(constancyOfTypeProvidedBySourceKeynode);
 
         if (canTargetTypeWithoutConstancySubtypeExtendToSourceType && doSourceAndTargetHaveCompatibleConstancySubtypes)
@@ -514,7 +514,7 @@ void Parser::ProcessTriple(
         else if (!typeProvidedBySourceKeynode.CanExtendTo(targetType))
           SC_THROW_EXCEPTION(
               utils::ExceptionParseError,
-              "Can't extend type `" << std::string(targetType) << "` using type `" 
+              "Can't extend type `" << std::string(targetType) << "` using type `"
                                     << std::string(typeProvidedBySourceKeynode) << "` for specified sc-element.");
       }
 
@@ -686,7 +686,7 @@ void Parser::ProcessContourEnd(ElementHandle const & contourHandle)
   {
     auto const & element = GetParsedElement(elementHandle);
 
-    // Add sc-arc from structure to element type if element type has not only outgoing base sc-arcs 
+    // Add sc-arc from structure to element type if element type has not only outgoing base sc-arcs
     auto const & range = m_elementTypeNotOutgoingBaseArcsToElementTypes.equal_range(element.GetIdtf());
     for (auto it = range.first; it != range.second; ++it)
     {

--- a/sc-memory/sc-memory/src/scs/scs_parser.cpp
+++ b/sc-memory/sc-memory/src/scs/scs_parser.cpp
@@ -490,7 +490,8 @@ void Parser::ProcessTriple(
             "Can't extend type `" << std::string(targetType) << "` using type `" << std::string(sourceType)
                                   << "` for specified sc-element, because sc-element `" << target.GetIdtf()
                                   << "` is sc-element denoting type of sc-elements.");
-      else if (ScType(targetType.BitAnd(~(ScType::Const | ScType::Var))).CanExtendTo(sourceType))
+      else if (ScType(targetType.BitAnd(~(ScType::Const | ScType::Var))).CanExtendTo(sourceType) 
+          && ScType(sourceType.BitAnd((ScType::Const | ScType::Var))).CanExtendTo(targetType.BitAnd((ScType::Const | ScType::Var))))
         target.m_type = newTargetType;
       else if (!sourceType.CanExtendTo(targetType))
         SC_THROW_EXCEPTION(

--- a/sc-memory/sc-memory/src/scs/scs_parser.cpp
+++ b/sc-memory/sc-memory/src/scs/scs_parser.cpp
@@ -502,12 +502,12 @@ void Parser::ProcessTriple(
             = targetTypeWithoutConstancySubtype.CanExtendTo(typeProvidedBySourceKeynode);
 
         // After check that constancy subtypes of source and target types are compatible for extension.
-        ScType const & sourceTypeWithConstancySubtype 
+        ScType const & constancyOfTypeProvidedBySourceKeynode 
             = typeProvidedBySourceKeynode.BitAnd(ScType::Const | ScType::Var);
-        ScType const & targetTypeWithConstancySubtype = targetType.BitAnd(ScType::Const | ScType::Var);
+        ScType const & targetTypeConstancy = targetType.BitAnd(ScType::Const | ScType::Var);
         bool doSourceAndTargetHaveCompatibleConstancySubtypes =
-            sourceTypeWithConstancySubtype.CanExtendTo(targetTypeWithConstancySubtype) 
-            || targetTypeWithConstancySubtype.CanExtendTo(sourceTypeWithConstancySubtype);
+            constancyOfTypeProvidedBySourceKeynode.CanExtendTo(targetTypeConstancy) 
+            || targetTypeConstancy.CanExtendTo(constancyOfTypeProvidedBySourceKeynode);
 
         if (canTargetTypeWithoutConstancySubtypeExtendToSourceType && doSourceAndTargetHaveCompatibleConstancySubtypes)
           target.m_type = newTargetType;

--- a/sc-memory/sc-memory/src/scs/scs_parser.cpp
+++ b/sc-memory/sc-memory/src/scs/scs_parser.cpp
@@ -490,14 +490,30 @@ void Parser::ProcessTriple(
             "Can't extend type `" << std::string(targetType) << "` using type `" << std::string(sourceType)
                                   << "` for specified sc-element, because sc-element `" << target.GetIdtf()
                                   << "` is sc-element denoting type of sc-elements.");
-      else if (ScType(targetType.BitAnd(~(ScType::Const | ScType::Var))).CanExtendTo(sourceType) 
-          && ScType(sourceType.BitAnd((ScType::Const | ScType::Var))).CanExtendTo(targetType.BitAnd((ScType::Const | ScType::Var))))
-        target.m_type = newTargetType;
-      else if (!sourceType.CanExtendTo(targetType))
-        SC_THROW_EXCEPTION(
-            utils::ExceptionParseError,
-            "Can't extend type `" << std::string(targetType) << "` using type `" << std::string(sourceType)
-                                  << "` for specified sc-element.");
+      else
+      {
+        // Check that any type of target sc-element without constancy mask can be extended to type of sc-elements 
+        // represented by source sc-element.
+        ScType const & targetTypeWithoutConstancyMask = targetType.BitAnd(~(ScType::Const | ScType::Var));
+        bool canTargetTypeWithoutConstancyMaskExtendToSourceType 
+            = targetTypeWithoutConstancyMask.CanExtendTo(sourceType);
+
+        // Check that any type of source sc-element with constancy mask can be extended to type of sc-elements 
+        // represented by source sc-element with constancy mask.
+        ScType const & sourceTypeWithConstancyMask = sourceType.BitAnd(ScType::Const | ScType::Var);
+        ScType const & targetTypeWithConstancyMask = targetType.BitAnd(ScType::Const | ScType::Var);
+        bool canSourceTypeWithConstancyMaskExtendToTargetTypeWithConstancyMask =
+            sourceTypeWithConstancyMask.CanExtendTo(targetTypeWithConstancyMask);
+
+        if (canTargetTypeWithoutConstancyMaskExtendToSourceType
+            && canSourceTypeWithConstancyMaskExtendToTargetTypeWithConstancyMask)
+          target.m_type = newTargetType;
+        else if (!sourceType.CanExtendTo(targetType))
+          SC_THROW_EXCEPTION(
+              utils::ExceptionParseError,
+              "Can't extend type `" << std::string(targetType) << "` using type `" << std::string(sourceType)
+                                    << "` for specified sc-element.");
+      }
 
       // TODO(NikitaZotov): Unfortunately, parser collects all sc.s-elements, and only then forms sc.s-triples based on
       // the parsed sc.s-elements. Due to this, it is difficult to handle cases when it is necessary not to generate a

--- a/sc-memory/sc-memory/src/scs/scs_types.cpp
+++ b/sc-memory/sc-memory/src/scs/scs_types.cpp
@@ -16,7 +16,7 @@ TypeResolver::SCsDesignationsToScTypes TypeResolver::ms_connectorsToTypes = {
     {"?=>", ScType::CommonArc},
     {"<=?", ScType::CommonArc},
 
-    {"?.?>", ScType::MembershipArc}, 
+    {"?.?>", ScType::MembershipArc},
     {"<?.?", ScType::MembershipArc},
 
     {"<=>", ScType::ConstCommonEdge},
@@ -27,9 +27,9 @@ TypeResolver::SCsDesignationsToScTypes TypeResolver::ms_connectorsToTypes = {
     {"_=>", ScType::VarCommonArc},
     {"<=_", ScType::VarCommonArc},
 
-    {".?>", ScType::ConstMembershipArc}, 
+    {".?>", ScType::ConstMembershipArc},
     {"<?.", ScType::ConstMembershipArc},
-    {"_.?>", ScType::VarMembershipArc}, 
+    {"_.?>", ScType::VarMembershipArc},
     {"<?._", ScType::VarMembershipArc},
 
     {"?.>", ScType::PosArc},
@@ -44,7 +44,7 @@ TypeResolver::SCsDesignationsToScTypes TypeResolver::ms_connectorsToTypes = {
     {".>", ScType::ConstPosArc},
     {"<.", ScType::ConstPosArc},
     {"_.>", ScType::VarPosArc},
-    {"<._", ScType::VarPosArc},      
+    {"<._", ScType::VarPosArc},
 
     {".|>", ScType::ConstNegArc},
     {"<|.", ScType::ConstNegArc},
@@ -177,7 +177,7 @@ struct TypeResolver::ScTypeHashFunc
 };
 
 TypeResolver::ScTypesToSCsDesignations TypeResolver::ms_typesToConnectors = {
-    {ScType::CommonEdge, "?<=>"}, 
+    {ScType::CommonEdge, "?<=>"},
     {ScType::CommonArc, "?=>"},
     {ScType::MembershipArc, "?.?>"},
     {ScType::ConstCommonEdge, "<=>"},
@@ -231,11 +231,10 @@ TypeResolver::ScTypesToSCsDesignations TypeResolver::ms_typesToConnectors = {
     {ScType::ConstActualTempNegArc, "~|>"},
     {ScType::VarActualTempNegArc, "_~|>"},
     {ScType::ConstInactualTempNegArc, "%|>"},
-    {ScType::VarInactualTempNegArc, "_%|>"}
-};
+    {ScType::VarInactualTempNegArc, "_%|>"}};
 
 TypeResolver::ScTypesToSCsDesignations TypeResolver::ms_typesToReverseConnectors = {
-    {ScType::CommonEdge, "?<=>"}, 
+    {ScType::CommonEdge, "?<=>"},
     {ScType::CommonArc, "<=?"},
     {ScType::MembershipArc, "<?.?"},
     {ScType::ConstCommonEdge, "<=>"},
@@ -289,8 +288,7 @@ TypeResolver::ScTypesToSCsDesignations TypeResolver::ms_typesToReverseConnectors
     {ScType::ConstActualTempNegArc, "<|~"},
     {ScType::VarActualTempNegArc, "<|~_"},
     {ScType::ConstInactualTempNegArc, "<|%"},
-    {ScType::VarInactualTempNegArc, "<|%_"}
-};
+    {ScType::VarInactualTempNegArc, "<|%_"}};
 
 TypeResolver::SCsDesignationsToScTypes TypeResolver::ms_keynodesToTypes = {
     {"sc_node", ScType::Node},
@@ -348,15 +346,18 @@ TypeResolver::ScTypesToSCsDesignations TypeResolver::ms_typesToKeynodes = {
 };
 
 TypeResolver::SCsConnectorDesignations TypeResolver::ms_reversedConnectors = {
-    "<=?", "<?.?", "<=", "<=_", 
-    "<.", "<._", "<?.", "<?._", "<.?", "<|.?", "</?", "<?-?", "<?..?", "<?~?", "<?%?",
-    "<-?", "<|-?", "<..?", "<~?", "<%?", "<|..?", "<|~?", "<|%?", 
-    "<-", "<-_", "<|-", "<|-_", "</", "</-", "</_", "</-_", 
-    "<..", "<.._", "<|..", "<|.._", "<~", "<~_", "<|~", "|<~_", "<%", "<%_", "<|%", "|<%_"
-};
+    "<=?",  "<?.?",  "<=",   "<=_",  "<.",   "<._",  "<?.",  "<?._", "<.?",  "<|.?",  "</?",
+    "<?-?", "<?..?", "<?~?", "<?%?", "<-?",  "<|-?", "<..?", "<~?",  "<%?",  "<|..?", "<|~?",
+    "<|%?", "<-",    "<-_",  "<|-",  "<|-_", "</",   "</-",  "</_",  "</-_", "<..",   "<.._",
+    "<|..", "<|.._", "<~",   "<~_",  "<|~",  "|<~_", "<%",   "<%_",  "<|%",  "|<%_"};
 
 TypeResolver::SCsConnectorDesignations TypeResolver::ms_deprecatedReversedConnectors = {
-    "<", "_<=", "_<-", "_<|-", "_<~", "_<|~",
+    "<",
+    "_<=",
+    "_<-",
+    "_<|-",
+    "_<~",
+    "_<|~",
 };
 
 std::string TypeResolver::GetDirectSCsConnector(ScType const & type)
@@ -398,17 +399,20 @@ ScType const & TypeResolver::GetConnectorType(std::string const & connectorAlias
       if (deprecatedReverseIt == ms_deprecatedReverseConnectorsToTypes.cend())
         return ScType::Unknown;
 
-      SC_LOG_WARNING("Specified reverse designation of sc-connector `" << connectorAlias << "` is deprecated"
-        " in SCs-code, use `" << ms_typesToReverseConnectors[deprecatedReverseIt->second] << "` instead.");
-      
+      SC_LOG_WARNING(
+          "Specified reverse designation of sc-connector `" << connectorAlias << "` is deprecated in SCs-code, use `"
+                                                            << ms_typesToReverseConnectors[deprecatedReverseIt->second]
+                                                            << "` instead.");
+
       return deprecatedReverseIt->second;
     }
 
-    SC_LOG_WARNING("Specified designation of sc-connector `" << connectorAlias << "` is deprecated"
-        " in SCs-code, use `" << ms_typesToConnectors[deprecatedIt->second] << "` instead.");
+    SC_LOG_WARNING(
+        "Specified designation of sc-connector `" << connectorAlias << "` is deprecated in SCs-code, use `"
+                                                  << ms_typesToConnectors[deprecatedIt->second] << "` instead.");
     return deprecatedIt->second;
-  } 
-  
+  }
+
   return it->second;
 }
 
@@ -421,8 +425,9 @@ ScType const & TypeResolver::GetElementType(std::string const & keynodeAlias)
     if (deprecatedIt == ms_deprecatedKeynodesToTypes.cend())
       return ScType::Unknown;
 
-    SC_LOG_WARNING("Specified sc-type class `" << keynodeAlias << "` is deprecated in SCs-code, "
-        << "use `" << ms_typesToKeynodes[deprecatedIt->second] << "` instead.");
+    SC_LOG_WARNING(
+        "Specified sc-type class `" << keynodeAlias << "` is deprecated in SCs-code, "
+                                    << "use `" << ms_typesToKeynodes[deprecatedIt->second] << "` instead.");
 
     return deprecatedIt->second;
   }
@@ -433,7 +438,7 @@ ScType const & TypeResolver::GetElementType(std::string const & keynodeAlias)
 bool TypeResolver::IsConnectorReversed(std::string const & connectorAlias)
 {
   return ms_reversedConnectors.find(connectorAlias) != ms_reversedConnectors.cend()
-    || ms_deprecatedReversedConnectors.find(connectorAlias) != ms_deprecatedReversedConnectors.cend();
+         || ms_deprecatedReversedConnectors.find(connectorAlias) != ms_deprecatedReversedConnectors.cend();
 }
 
 bool TypeResolver::IsConst(std::string const & idtf)
@@ -456,8 +461,8 @@ bool TypeResolver::IsConnectorAttrConst(std::string const & attr)
 
 bool TypeResolver::IsElementType(std::string const & alias)
 {
-  return ms_keynodesToTypes.find(alias) != ms_keynodesToTypes.cend() 
-     || ms_deprecatedKeynodesToTypes.find(alias) != ms_deprecatedKeynodesToTypes.cend();
+  return ms_keynodesToTypes.find(alias) != ms_keynodesToTypes.cend()
+         || ms_deprecatedKeynodesToTypes.find(alias) != ms_deprecatedKeynodesToTypes.cend();
 }
 
 bool TypeResolver::IsUnnamed(std::string const & alias)

--- a/sc-memory/sc-memory/src/scs/scs_types.cpp
+++ b/sc-memory/sc-memory/src/scs/scs_types.cpp
@@ -293,11 +293,6 @@ TypeResolver::ScTypesToSCsDesignations TypeResolver::ms_typesToReverseConnectors
 };
 
 TypeResolver::SCsDesignationsToScTypes TypeResolver::ms_keynodesToTypes = {
-    {"sc_common_edge", ScType::CommonEdge},
-    {"sc_common_arc", ScType::CommonArc},
-    {"sc_membership_arc", ScType::MembershipArc},
-    {"sc_main_arc", ScType::ConstPermPosArc},
-
     {"sc_node", ScType::Node},
     {"sc_link", ScType::NodeLink},
     {"sc_link_class", ScType::NodeLinkClass},
@@ -308,9 +303,19 @@ TypeResolver::SCsDesignationsToScTypes TypeResolver::ms_keynodesToTypes = {
     {"sc_node_non_role_relation", ScType::NodeNonRole},
     {"sc_node_superclass", ScType::NodeSuperclass},
     {"sc_node_material", ScType::NodeMaterial},
+
+    {"sc_common_edge", ScType::CommonEdge},
+    {"sc_common_arc", ScType::CommonArc},
+    {"sc_membership_arc", ScType::MembershipArc},
+    {"sc_main_arc", ScType::ConstPermPosArc},
 };
 
 TypeResolver::SCsDesignationsToScTypes TypeResolver::ms_deprecatedKeynodesToTypes = {
+    {"sc_node_not_binary_tuple", ScType::NodeTuple},
+    {"sc_node_struct", ScType::NodeStructure},
+    {"sc_node_not_relation", ScType::NodeClass},
+    {"sc_node_norole_relation", ScType::NodeNonRole},
+
     {"sc_edge", ScType::CommonEdge},
     {"sc_edge_ucommon", ScType::CommonEdge},
 
@@ -322,11 +327,6 @@ TypeResolver::SCsDesignationsToScTypes TypeResolver::ms_deprecatedKeynodesToType
 
     {"sc_arc_access", ScType::MembershipArc},
     {"sc_edge_access", ScType::MembershipArc},
-
-    {"sc_node_not_binary_tuple", ScType::NodeTuple},
-    {"sc_node_struct", ScType::NodeStructure},
-    {"sc_node_not_relation", ScType::NodeClass},
-    {"sc_node_norole_relation", ScType::NodeNonRole},
 };
 
 TypeResolver::ScTypesToSCsDesignations TypeResolver::ms_typesToKeynodes = {
@@ -379,8 +379,8 @@ std::string TypeResolver::GetReverseSCsConnector(ScType const & type)
 
 std::string TypeResolver::GetSCsElementKeynode(ScType const & type)
 {
-  auto const it = ms_typesToKeynodes.find(type);
-  if (it == ms_typesToKeynodes.cend())
+   auto const it = ms_typesToKeynodes.find(type);
+   if (it == ms_typesToKeynodes.cend())
     return "";
 
   return it->second;
@@ -412,7 +412,7 @@ ScType const & TypeResolver::GetConnectorType(std::string const & connectorAlias
   return it->second;
 }
 
-ScType const & TypeResolver::GetKeynodeType(std::string const & keynodeAlias)
+ScType const & TypeResolver::GetElementType(std::string const & keynodeAlias)
 {
   auto const it = ms_keynodesToTypes.find(keynodeAlias);
   if (it == ms_keynodesToTypes.cend())
@@ -454,10 +454,10 @@ bool TypeResolver::IsConnectorAttrConst(std::string const & attr)
   return attr == ":";
 }
 
-bool TypeResolver::IsKeynodeType(std::string const & alias)
+bool TypeResolver::IsElementType(std::string const & alias)
 {
   return ms_keynodesToTypes.find(alias) != ms_keynodesToTypes.cend() 
-    || ms_deprecatedKeynodesToTypes.find(alias) != ms_deprecatedKeynodesToTypes.cend();
+     || ms_deprecatedKeynodesToTypes.find(alias) != ms_deprecatedKeynodesToTypes.cend();
 }
 
 bool TypeResolver::IsUnnamed(std::string const & alias)

--- a/sc-memory/sc-memory/src/scs/scs_types.cpp
+++ b/sc-memory/sc-memory/src/scs/scs_types.cpp
@@ -379,8 +379,8 @@ std::string TypeResolver::GetReverseSCsConnector(ScType const & type)
 
 std::string TypeResolver::GetSCsElementKeynode(ScType const & type)
 {
-   auto const it = ms_typesToKeynodes.find(type);
-   if (it == ms_typesToKeynodes.cend())
+  auto const it = ms_typesToKeynodes.find(type);
+  if (it == ms_typesToKeynodes.cend())
     return "";
 
   return it->second;

--- a/sc-memory/sc-memory/tests/sc-memory/units/common/test_sc_type.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/common/test_sc_type.cpp
@@ -337,6 +337,9 @@ TEST(ScTypeTest, ExtendTypes)
   EXPECT_TRUE(ScType::ConstFuzArc.CanExtendTo(ScType::ConstFuzArc));
   EXPECT_FALSE(ScType::ConstFuzArc.CanExtendTo(ScType::ConstPermNegArc));
   EXPECT_FALSE(ScType::ConstFuzArc.CanExtendTo(ScType::VarFuzArc));
+
+  EXPECT_FALSE(ScType::ConstPermPosArc.CanExtendTo(ScType::VarPermPosArc));
+  EXPECT_FALSE(ScType::VarPermPosArc.CanExtendTo(ScType::ConstPermPosArc));
 }
 
 TEST(ScTypeTest, CheckReverseSCsConnectors)

--- a/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
@@ -20,7 +20,7 @@ public:
   }
 };
 
-} // namespace
+}  // namespace
 
 using SCsHelperTest = ScMemoryTest;
 
@@ -28,12 +28,11 @@ SC_PRAGMA_DISABLE_DEPRECATION_WARNINGS_BEGIN
 
 TEST_F(SCsHelperTest, GenerateBySCs)
 {
-  std::vector<std::pair<std::string, std::string>> tests =
-  {
-    { "x -> y;;", "x _-> _y;;" },
-    { "x1 => nrel_x1: [test_content*];;", "x1 _=> nrel_x1:: _[];;" },
-    { "x2 ~> y2 (* <- z2;; *);;", "x2 _~> _y2 (* <-_ _z2;; *);;" },
-    { "x3 <- y3 (* <- sc_node_class;; *);;", "sc_node_class -> _y3;; _y3 _-> x3;;" },
+  std::vector<std::pair<std::string, std::string>> tests = {
+      {"x -> y;;", "x _-> _y;;"},
+      {"x1 => nrel_x1: [test_content*];;", "x1 _=> nrel_x1:: _[];;"},
+      {"x2 ~> y2 (* <- z2;; *);;", "x2 _~> _y2 (* <-_ _z2;; *);;"},
+      {"x3 <- y3 (* <- sc_node_class;; *);;", "sc_node_class -> _y3;; _y3 _-> x3;;"},
   };
 
   for (auto const & t : tests)
@@ -99,11 +98,11 @@ TEST_F(SCsHelperTest, GenerateBySCs_Aliases)
 TEST_F(SCsHelperTest, GenerateBySCs_Contents)
 {
   std::string const dataString = "v_string -> [string];;";
-  std::string const dataFloat  = "v_float -> [^\"float:7\"];;";
+  std::string const dataFloat = "v_float -> [^\"float:7\"];;";
   std::string const dataDouble = "v_double -> [^\"double:8\"];;";
-  std::string const dataInt16  = "v_int16 -> [^\"int16:10\"];;";
-  std::string const dataInt32  = "v_int32 -> [^\"int32:11\"];;";
-  std::string const dataInt64  = "v_int64 -> [^\"int64:12\"];;";
+  std::string const dataInt16 = "v_int16 -> [^\"int16:10\"];;";
+  std::string const dataInt32 = "v_int32 -> [^\"int32:11\"];;";
+  std::string const dataInt64 = "v_int64 -> [^\"int64:12\"];;";
   std::string const dataUint16 = "v_uint16 -> [^\"uint16:14\"];;";
   std::string const dataUint32 = "v_uint32 -> [^\"uint32:15\"];;";
   std::string const dataUint64 = "v_uint64 -> [^\"uint64:16\"];;";
@@ -256,9 +255,9 @@ TEST_F(SCsHelperTest, GenerateBySCs_ElementTypeArcWithRoleWithinStructure)
 TEST_F(SCsHelperTest, GenerateBySCs_NotConstPermPosArcFromElementTypeWithinStructure)
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
-  std::string const scsData = 
-    "structure = [* sc_node_class => ..relation: class;; *];;"
-    "..relation <- sc_node_non_role_relation;;";
+  std::string const scsData =
+      "structure = [* sc_node_class => ..relation: class;; *];;"
+      "..relation <- sc_node_non_role_relation;;";
   EXPECT_TRUE(helper.GenerateBySCsText(scsData));
 
   ScAddr const & nodeClassAddr = m_ctx->SearchElementBySystemIdentifier("sc_node_class");
@@ -268,13 +267,7 @@ TEST_F(SCsHelperTest, GenerateBySCs_NotConstPermPosArcFromElementTypeWithinStruc
   EXPECT_TRUE(nodeAddr.IsValid());
 
   ScTemplate templ;
-  templ.Quintuple(
-    nodeClassAddr,
-    ScType::VarCommonArc,
-    nodeAddr,
-    ScType::VarPermPosArc,
-    ScType::VarNodeNonRole
-  );
+  templ.Quintuple(nodeClassAddr, ScType::VarCommonArc, nodeAddr, ScType::VarPermPosArc, ScType::VarNodeNonRole);
   ScTemplateSearchResult result;
   EXPECT_TRUE(m_ctx->SearchByTemplate(templ, result));
   EXPECT_EQ(result.Size(), 1u);
@@ -344,9 +337,9 @@ TEST_F(SCsHelperTest, GenerateBySCs_ContourWithImplicitlySpecifiedElementTypeSys
 TEST_F(SCsHelperTest, DISABLED_GenerateBySCs_ContourWithExplicitlySpecifiedElementTypeSystemIdentifier)
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
-  std::string const scsData = 
-    "..contour = [* sc_node -> sc_node_class;; *];;"
-    "..contour => nrel_system_identifier: [sc_node_class];;";
+  std::string const scsData =
+      "..contour = [* sc_node -> sc_node_class;; *];;"
+      "..contour => nrel_system_identifier: [sc_node_class];;";
   EXPECT_FALSE(helper.GenerateBySCsText(scsData));
 }
 
@@ -566,7 +559,6 @@ TEST_F(SCsHelperTest, GenerateBySCs_Visibility_System)
   }
 }
 
-
 TEST_F(SCsHelperTest, GenerateBySCs_Visibility_Global)
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
@@ -624,32 +616,32 @@ TEST_F(SCsHelperTest, GenerateAppendToStructure)
   EXPECT_TRUE(outputStructure.IsValid());
 
   EXPECT_TRUE(helper.GenerateBySCsText(
-    "class_1 -> class_1_instance_1;;"
-    "class_1 -> class_1_instance_2;;"
-    "class_1_instance_1 => rel_1: class_1_instance_2;;"
-    "class_1_instance_2 => rel_2: class_1_instance_1;;",
-    outputStructure
-  ));
+      "class_1 -> class_1_instance_1;;"
+      "class_1 -> class_1_instance_2;;"
+      "class_1_instance_1 => rel_1: class_1_instance_2;;"
+      "class_1_instance_2 => rel_2: class_1_instance_1;;",
+      outputStructure));
 
   ScTemplate templ;
   m_ctx->BuildTemplate(
-    templ,
-    "class_1 _-> _class_1_instance_1;;"
-    "class_1 _-> _class_1_instance_2;;"
-    "_class_1_instance_1 _=> rel_1:: _class_1_instance_2;;"
-    "_class_1_instance_2 _=> rel_2:: _class_1_instance_1;;"
-  );
+      templ,
+      "class_1 _-> _class_1_instance_1;;"
+      "class_1 _-> _class_1_instance_2;;"
+      "_class_1_instance_1 _=> rel_1:: _class_1_instance_2;;"
+      "_class_1_instance_2 _=> rel_2:: _class_1_instance_1;;");
 
   ScTemplateSearchResult result;
   EXPECT_TRUE(m_ctx->SearchByTemplate(templ, result));
   EXPECT_EQ(result.Size(), 1u);
 
-  result.ForEach([this, &outputStructure](ScTemplateSearchResultItem const & item) {
-    for (size_t i = 0; i < item.Size(); ++i)
-    {
-      EXPECT_TRUE(m_ctx->CheckConnector(outputStructure, item[i], ScType::ConstPermPosArc));
-    }
-  });
+  result.ForEach(
+      [this, &outputStructure](ScTemplateSearchResultItem const & item)
+      {
+        for (size_t i = 0; i < item.Size(); ++i)
+        {
+          EXPECT_TRUE(m_ctx->CheckConnector(outputStructure, item[i], ScType::ConstPermPosArc));
+        }
+      });
 }
 
 TEST_F(SCsHelperTest, GenerateStructureAppendToStructure)
@@ -660,32 +652,34 @@ TEST_F(SCsHelperTest, GenerateStructureAppendToStructure)
   EXPECT_TRUE(outputStructure.IsValid());
 
   EXPECT_TRUE(helper.GenerateBySCsText(
-    "example_structure = [*"
-    "class_1 -> class_1_instance_1;;" // 3 new sc-elements
-    "class_1 -> class_1_instance_2;;" // 2 new sc-elements
-    "class_1_instance_1 => rel_1: class_1_instance_2;;" // 3 new sc-elements
-    "class_1_instance_2 => rel_2: class_1_instance_1;;" // 3 new sc-elements
-    "*];;", // example_structure must contains 11 sc-elements
-    outputStructure
-  ));
+      "example_structure = [*"
+      "class_1 -> class_1_instance_1;;"                    // 3 new sc-elements
+      "class_1 -> class_1_instance_2;;"                    // 2 new sc-elements
+      "class_1_instance_1 => rel_1: class_1_instance_2;;"  // 3 new sc-elements
+      "class_1_instance_2 => rel_2: class_1_instance_1;;"  // 3 new sc-elements
+      "*];;",                                              // example_structure must contains 11 sc-elements
+      outputStructure));
 
   ScAddr const & exampleStructure = m_ctx->SearchElementBySystemIdentifier("example_structure");
   EXPECT_EQ(m_ctx->GetElementType(exampleStructure), ScType::ConstNodeStructure);
 
-  auto const checkInStruct = [this, outputStructure](std::string const & scsText, size_t const expectedStructNum) {
+  auto const checkInStruct = [this, outputStructure](std::string const & scsText, size_t const expectedStructNum)
+  {
     ScTemplate templ;
-   m_ctx->BuildTemplate(templ, scsText);
+    m_ctx->BuildTemplate(templ, scsText);
 
     ScTemplateSearchResult result;
     EXPECT_TRUE(m_ctx->SearchByTemplate(templ, result));
     EXPECT_EQ(result.Size(), expectedStructNum);
 
-    result.ForEach([this, &outputStructure](ScTemplateSearchResultItem const & item) {
-      for (size_t i = 0; i < item.Size(); ++i)
-      {
-        EXPECT_TRUE(m_ctx->CheckConnector(outputStructure, item[i], ScType::ConstPermPosArc));
-      }
-    });
+    result.ForEach(
+        [this, &outputStructure](ScTemplateSearchResultItem const & item)
+        {
+          for (size_t i = 0; i < item.Size(); ++i)
+          {
+            EXPECT_TRUE(m_ctx->CheckConnector(outputStructure, item[i], ScType::ConstPermPosArc));
+          }
+        });
   };
 
   checkInStruct(
@@ -693,19 +687,12 @@ TEST_F(SCsHelperTest, GenerateStructureAppendToStructure)
       "class_1 _-> _class_1_instance_2;;"
       "_class_1_instance_1 _=> rel_1:: _class_1_instance_2;;"
       "_class_1_instance_2 _=> rel_2:: _class_1_instance_1;;",
-      1u
-  );
-  checkInStruct(
-      "example_structure _-> _...;;",
-      5u
-  );
-  checkInStruct(
-      "example_structure _-> (_... _-> _...);;",
-      4u
-  );
+      1u);
+  checkInStruct("example_structure _-> _...;;", 5u);
+  checkInStruct("example_structure _-> (_... _-> _...);;", 4u);
   checkInStruct(
       "example_structure _-> (_... _=> _...);;",
-      2u // total 5 + 4 + 2 = 11 sc-elements
+      2u  // total 5 + 4 + 2 = 11 sc-elements
   );
 }
 
@@ -715,163 +702,166 @@ TEST_F(SCsHelperTest, FindTriplesSmoke)
 
   ScAddr const & outputStructureWithRuMainIdtf = m_ctx->GenerateNode(ScType::ConstNodeStructure);
   EXPECT_TRUE(outputStructureWithRuMainIdtf.IsValid());
-  EXPECT_TRUE(helper.GenerateBySCsText(
-      "test_node => nrel_main_idtf: [] (* <- lang_ru;; *);;",
-      outputStructureWithRuMainIdtf
-  ));
+  EXPECT_TRUE(
+      helper.GenerateBySCsText("test_node => nrel_main_idtf: [] (* <- lang_ru;; *);;", outputStructureWithRuMainIdtf));
 
   ScAddr const & outputStructureWithEnMainIdtf = m_ctx->GenerateNode(ScType::ConstNodeStructure);
   EXPECT_TRUE(outputStructureWithEnMainIdtf.IsValid());
-  EXPECT_TRUE(helper.GenerateBySCsText(
-      "test_node => nrel_main_idtf: [] (* <- lang_en;; *);;",
-      outputStructureWithEnMainIdtf
-  ));
+  EXPECT_TRUE(
+      helper.GenerateBySCsText("test_node => nrel_main_idtf: [] (* <- lang_en;; *);;", outputStructureWithEnMainIdtf));
 
   ScAddr const & outputStructureWithRuIdtf = m_ctx->GenerateNode(ScType::ConstNodeStructure);
   EXPECT_TRUE(outputStructureWithRuIdtf.IsValid());
-  EXPECT_TRUE(helper.GenerateBySCsText(
-      "test_node => nrel_idtf: [] (* <- lang_ru;; *);;",
-      outputStructureWithRuIdtf
-  ));
+  EXPECT_TRUE(helper.GenerateBySCsText("test_node => nrel_idtf: [] (* <- lang_ru;; *);;", outputStructureWithRuIdtf));
 
   ScAddr const & outputStructureWithEnIdtf = m_ctx->GenerateNode(ScType::ConstNodeStructure);
   EXPECT_TRUE(outputStructureWithEnIdtf.IsValid());
-  EXPECT_TRUE(helper.GenerateBySCsText(
-      "test_node => nrel_idtf: [] (* <- lang_en;; *);;",
-      outputStructureWithEnIdtf
-  ));
+  EXPECT_TRUE(helper.GenerateBySCsText("test_node => nrel_idtf: [] (* <- lang_en;; *);;", outputStructureWithEnIdtf));
 
-  EXPECT_TRUE(helper.GenerateBySCsText(
-      "lang_ru -> [];;"
-      "lang_en -> [];;"
-      "test_node => identification: [] (* <- lang_ru;; *);;"
-      "test_node => identification: [] (* <- lang_en;; *);;"
-  ));
+  EXPECT_TRUE(
+      helper.GenerateBySCsText("lang_ru -> [];;"
+                               "lang_en -> [];;"
+                               "test_node => identification: [] (* <- lang_ru;; *);;"
+                               "test_node => identification: [] (* <- lang_en;; *);;"));
 
   ScTemplate templ;
-  m_ctx->BuildTemplate(
-      templ,
-      "test_node _=> nrel_main_idtf:: _[] (* <-_ lang_ru;; *);;"
-  );
+  m_ctx->BuildTemplate(templ, "test_node _=> nrel_main_idtf:: _[] (* <-_ lang_ru;; *);;");
 
   ScTemplateSearchResult result;
   EXPECT_TRUE(m_ctx->SearchByTemplate(templ, result));
   EXPECT_EQ(result.Size(), 1u);
 
-  result.ForEach([this, &outputStructureWithRuMainIdtf](ScTemplateSearchResultItem const & item) {
-    for (size_t i = 0; i < item.Size(); ++i)
-    {
-      EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithRuMainIdtf, item[i], ScType::ConstPermPosArc));
-    }
-  });
+  result.ForEach(
+      [this, &outputStructureWithRuMainIdtf](ScTemplateSearchResultItem const & item)
+      {
+        for (size_t i = 0; i < item.Size(); ++i)
+        {
+          EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithRuMainIdtf, item[i], ScType::ConstPermPosArc));
+        }
+      });
 
   result.Clear();
   {
     bool isFound = false;
-    m_ctx->SearchByTemplate(templ, [this, &isFound, &outputStructureWithRuMainIdtf](ScTemplateSearchResultItem const & item) {
-      isFound = true;
-      for (size_t i = 0; i < item.Size(); ++i)
-      {
-        EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithRuMainIdtf, item[i], ScType::ConstPermPosArc));
-      }
-    }, [this, outputStructureWithRuMainIdtf](ScAddr const & elementAddr) -> bool {
-      return m_ctx->CheckConnector(outputStructureWithRuMainIdtf, elementAddr, ScType::ConstPermPosArc);
-    });
+    m_ctx->SearchByTemplate(
+        templ,
+        [this, &isFound, &outputStructureWithRuMainIdtf](ScTemplateSearchResultItem const & item)
+        {
+          isFound = true;
+          for (size_t i = 0; i < item.Size(); ++i)
+          {
+            EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithRuMainIdtf, item[i], ScType::ConstPermPosArc));
+          }
+        },
+        [this, outputStructureWithRuMainIdtf](ScAddr const & elementAddr) -> bool
+        {
+          return m_ctx->CheckConnector(outputStructureWithRuMainIdtf, elementAddr, ScType::ConstPermPosArc);
+        });
     EXPECT_TRUE(isFound);
   }
 
   templ.Clear();
-  m_ctx->BuildTemplate(
-      templ,
-      "test_node _=> nrel_main_idtf:: _[] (* <-_ lang_en;; *);;"
-  );
+  m_ctx->BuildTemplate(templ, "test_node _=> nrel_main_idtf:: _[] (* <-_ lang_en;; *);;");
 
   result.Clear();
   EXPECT_TRUE(m_ctx->SearchByTemplate(templ, result));
   EXPECT_EQ(result.Size(), 1u);
-  result.ForEach([this, &outputStructureWithEnMainIdtf](ScTemplateSearchResultItem const & item) {
-    for (size_t i = 0; i < item.Size(); ++i)
-    {
-      EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithEnMainIdtf, item[i], ScType::ConstPermPosArc));
-    }
-  });
+  result.ForEach(
+      [this, &outputStructureWithEnMainIdtf](ScTemplateSearchResultItem const & item)
+      {
+        for (size_t i = 0; i < item.Size(); ++i)
+        {
+          EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithEnMainIdtf, item[i], ScType::ConstPermPosArc));
+        }
+      });
 
   result.Clear();
   {
     bool isFound = false;
-    m_ctx->SearchByTemplate(templ, [this, &isFound, &outputStructureWithEnMainIdtf](ScTemplateSearchResultItem const & item) {
-      isFound = true;
-      for (size_t i = 0; i < item.Size(); ++i)
-      {
-        EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithEnMainIdtf, item[i], ScType::ConstPermPosArc));
-      }
-    }, [this, outputStructureWithEnMainIdtf](ScAddr const & elementAddr) -> bool {
-      return m_ctx->CheckConnector(outputStructureWithEnMainIdtf, elementAddr, ScType::ConstPermPosArc);
-    });
+    m_ctx->SearchByTemplate(
+        templ,
+        [this, &isFound, &outputStructureWithEnMainIdtf](ScTemplateSearchResultItem const & item)
+        {
+          isFound = true;
+          for (size_t i = 0; i < item.Size(); ++i)
+          {
+            EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithEnMainIdtf, item[i], ScType::ConstPermPosArc));
+          }
+        },
+        [this, outputStructureWithEnMainIdtf](ScAddr const & elementAddr) -> bool
+        {
+          return m_ctx->CheckConnector(outputStructureWithEnMainIdtf, elementAddr, ScType::ConstPermPosArc);
+        });
     EXPECT_TRUE(isFound);
   }
 
   templ.Clear();
-  m_ctx->BuildTemplate(
-      templ,
-      "test_node _=> nrel_idtf:: _[] (* <-_ lang_ru;; *);;"
-  );
+  m_ctx->BuildTemplate(templ, "test_node _=> nrel_idtf:: _[] (* <-_ lang_ru;; *);;");
 
   result.Clear();
   EXPECT_TRUE(m_ctx->SearchByTemplate(templ, result));
   EXPECT_EQ(result.Size(), 1u);
-  result.ForEach([this, &outputStructureWithRuIdtf](ScTemplateSearchResultItem const & item) {
-    for (size_t i = 0; i < item.Size(); ++i)
-    {
-      EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithRuIdtf, item[i], ScType::ConstPermPosArc));
-    }
-  });
+  result.ForEach(
+      [this, &outputStructureWithRuIdtf](ScTemplateSearchResultItem const & item)
+      {
+        for (size_t i = 0; i < item.Size(); ++i)
+        {
+          EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithRuIdtf, item[i], ScType::ConstPermPosArc));
+        }
+      });
 
   result.Clear();
   {
     bool isFound = false;
-    m_ctx->SearchByTemplate(templ,[this, &isFound, &outputStructureWithRuIdtf](ScTemplateSearchResultItem const & item) {
-      isFound = true;
-      for (size_t i = 0; i < item.Size(); ++i)
-      {
-        EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithRuIdtf, item[i], ScType::ConstPermPosArc));
-      }
-    }, 
-    [this, outputStructureWithRuIdtf](ScAddr const & elementAddr) -> bool {
-      return m_ctx->CheckConnector(outputStructureWithRuIdtf, elementAddr, ScType::ConstPermPosArc);
-    });
+    m_ctx->SearchByTemplate(
+        templ,
+        [this, &isFound, &outputStructureWithRuIdtf](ScTemplateSearchResultItem const & item)
+        {
+          isFound = true;
+          for (size_t i = 0; i < item.Size(); ++i)
+          {
+            EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithRuIdtf, item[i], ScType::ConstPermPosArc));
+          }
+        },
+        [this, outputStructureWithRuIdtf](ScAddr const & elementAddr) -> bool
+        {
+          return m_ctx->CheckConnector(outputStructureWithRuIdtf, elementAddr, ScType::ConstPermPosArc);
+        });
     EXPECT_TRUE(isFound);
   }
 
   templ.Clear();
-  m_ctx->BuildTemplate(
-      templ,
-      "test_node _=> nrel_idtf:: _[] (* <-_ lang_en;; *);;"
-  );
+  m_ctx->BuildTemplate(templ, "test_node _=> nrel_idtf:: _[] (* <-_ lang_en;; *);;");
 
   result.Clear();
   EXPECT_TRUE(m_ctx->SearchByTemplate(templ, result));
   EXPECT_EQ(result.Size(), 1u);
-  result.ForEach([this, &outputStructureWithEnIdtf](ScTemplateSearchResultItem const & item) {
-    for (size_t i = 0; i < item.Size(); ++i)
-    {
-      EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithEnIdtf, item[i], ScType::ConstPermPosArc));
-    }
-  });
+  result.ForEach(
+      [this, &outputStructureWithEnIdtf](ScTemplateSearchResultItem const & item)
+      {
+        for (size_t i = 0; i < item.Size(); ++i)
+        {
+          EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithEnIdtf, item[i], ScType::ConstPermPosArc));
+        }
+      });
 
   result.Clear();
   {
     bool isFound = false;
-    m_ctx->SearchByTemplate(templ, [this, &isFound, &outputStructureWithEnIdtf](ScTemplateSearchResultItem const & item) {
-      isFound = true;
-      for (size_t i = 0; i < item.Size(); ++i)
-      {
-        EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithEnIdtf, item[i], ScType::ConstPermPosArc));
-      }
-    }, 
-    [this, outputStructureWithEnIdtf](ScAddr const & elementAddr) -> bool {
-      return m_ctx->CheckConnector(outputStructureWithEnIdtf, elementAddr, ScType::ConstPermPosArc);
-    });
+    m_ctx->SearchByTemplate(
+        templ,
+        [this, &isFound, &outputStructureWithEnIdtf](ScTemplateSearchResultItem const & item)
+        {
+          isFound = true;
+          for (size_t i = 0; i < item.Size(); ++i)
+          {
+            EXPECT_TRUE(m_ctx->CheckConnector(outputStructureWithEnIdtf, item[i], ScType::ConstPermPosArc));
+          }
+        },
+        [this, outputStructureWithEnIdtf](ScAddr const & elementAddr) -> bool
+        {
+          return m_ctx->CheckConnector(outputStructureWithEnIdtf, elementAddr, ScType::ConstPermPosArc);
+        });
     EXPECT_TRUE(isFound);
   }
 }

--- a/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
@@ -192,6 +192,9 @@ TEST_F(SCsHelperTest, GenerateBySCs_SingleNode)
   ScAddr const node = m_ctx->SearchElementBySystemIdentifier("node");
   EXPECT_TRUE(node.IsValid());
   EXPECT_EQ(m_ctx->GetElementType(node), ScType::ConstNodeClass);
+
+  ScAddr const nodeClass = m_ctx->SearchElementBySystemIdentifier("sc_node_class");
+  EXPECT_FALSE(m_ctx->CheckConnector(nodeClass, node, ScType::ConstPermPosArc));
 }
 
 TEST_F(SCsHelperTest, GenerateBySCs_Visibility_System)

--- a/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
@@ -197,63 +197,60 @@ TEST_F(SCsHelperTest, GenerateBySCs_SingleNode)
   EXPECT_FALSE(m_ctx->CheckConnector(nodeClass, node, ScType::ConstPermPosArc));
 }
 
-TEST_F(SCsHelperTest, GenerateBySCs_ElementTypes)
+TEST_F(SCsHelperTest, GenerateBySCs_ElementWithType)
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
-  std::string const scsData = "sc_node_class"
-    "-> class1;"
-    "-> rrel_1: class2;;"
-    "class3"
-    "-> sc_node_class;;"
-    "class4"
-    "-> rrel_1: sc_node_class;;"
-    "sc_node_class "
-    "_-> class5;"
-    "_-> _class6;"
-    "_-> rrel_3: class7;"
-    "_-> rrel_4:: _class8;;";
-
+  std::string const scsData = "sc_node_class -> class1;;";
   EXPECT_TRUE(helper.GenerateBySCsText(scsData));
+}
 
-  ScAddr const & nodeClass = m_ctx->SearchElementBySystemIdentifier("sc_node_class");
-  ScAddr const & class1 = m_ctx->SearchElementBySystemIdentifier("class1");
-  EXPECT_EQ(m_ctx->GetElementType(class1), ScType::ConstNodeClass);
-  EXPECT_FALSE(m_ctx->CheckConnector(nodeClass, class1, ScType::ConstPermPosArc));
+TEST_F(SCsHelperTest, GenerateBySCs_ElementTypeArcWithRole)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "sc_node_class -> rrel_1: class1;;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
 
-  ScAddr const & class2 = m_ctx->SearchElementBySystemIdentifier("class2");
-  EXPECT_EQ(m_ctx->GetElementType(class2), ScType::ConstNodeClass);
-  EXPECT_FALSE(m_ctx->CheckConnector(nodeClass, class2, ScType::ConstPermPosArc));
+TEST_F(SCsHelperTest, GenerateBySCs_NotConstPermPosArcFromElementType)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "sc_node_class => ..relation: class1;;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
 
-  ScAddr const & class3 = m_ctx->SearchElementBySystemIdentifier("class3");
-  EXPECT_EQ(m_ctx->GetElementType(class3), ScType::ConstNode);
-  EXPECT_TRUE(m_ctx->CheckConnector(class3, nodeClass, ScType::ConstPermPosArc));
+TEST_F(SCsHelperTest, GenerateBySCs_ArcToElementType)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "set -> sc_node_class;;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
 
-  ScAddr const & class4 = m_ctx->SearchElementBySystemIdentifier("class4");
-  EXPECT_EQ(m_ctx->GetElementType(class4), ScType::ConstNode);
-  EXPECT_TRUE(
-      m_ctx->CreateIterator5(class4, ScType::ConstPermPosArc, nodeClass, ScType::ConstPermPosArc, ScKeynodes::rrel_1)
-          ->Next());
+TEST_F(SCsHelperTest, GenerateBySCs_ElementWithTypeWithinStructure)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "structure = [* sc_node_class -> class1;; *];;";
+  EXPECT_TRUE(helper.GenerateBySCsText(scsData));
+}
 
-  ScAddr const & class5 = m_ctx->SearchElementBySystemIdentifier("class5");
-  EXPECT_EQ(m_ctx->GetElementType(class5), ScType::ConstNode);
-  EXPECT_TRUE(m_ctx->CheckConnector(nodeClass, class5, ScType::VarPermPosArc));
+TEST_F(SCsHelperTest, GenerateBySCs_ElementTypeArcWithRoleWithinStructure)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "structure = [* sc_node_class -> rrel_1: class1;; *];;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
 
-  ScAddr const & class6 = m_ctx->SearchElementBySystemIdentifier("_class6");
-  EXPECT_EQ(m_ctx->GetElementType(class6), ScType::VarNode);
-  EXPECT_TRUE(m_ctx->CheckConnector(nodeClass, class6, ScType::VarPermPosArc));
+TEST_F(SCsHelperTest, GenerateBySCs_NotConstPermPosArcFromElementTypeWithinStructure)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "structure = [* sc_node_class => ..relation: class1;; *];;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
 
-  ScAddr const & class7 = m_ctx->SearchElementBySystemIdentifier("class7");
-  EXPECT_EQ(m_ctx->GetElementType(class7), ScType::ConstNode);
-  EXPECT_TRUE(
-      m_ctx->CreateIterator5(nodeClass, ScType::VarPermPosArc, class7, ScType::ConstPermPosArc, ScKeynodes::rrel_3)
-          ->Next());
-
-  ScAddr const & class8 = m_ctx->SearchElementBySystemIdentifier("_class8");
-  ScAddr const & rrel_4 = m_ctx->SearchElementBySystemIdentifier("rrel_4");
-  EXPECT_EQ(m_ctx->GetElementType(class8), ScType::VarNode);
-  EXPECT_TRUE(
-      m_ctx->CreateIterator5(nodeClass, ScType::VarPermPosArc, class8, ScType::VarPermPosArc, rrel_4)
-          ->Next());
+TEST_F(SCsHelperTest, GenerateBySCs_ArcToElementTypeWithinStructure)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "structure = [* set -> sc_node_class;; *];;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
 }
 
 TEST_F(SCsHelperTest, GenerateBySCs_Visibility_System)

--- a/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
@@ -313,7 +313,7 @@ TEST_F(SCsHelperTest, GenerateBySCs_ArcToElementTypeWithinStructure)
 TEST_F(SCsHelperTest, GenerateBySCs_BaseArcBetweenElementTypesWithinStructure)
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
-  std::string const scsData = "structure = [* sc_node_tuple -> sc_node_class;; *];;";
+  std::string const scsData = "structure = [* sc_node -> sc_node_class;; *];;";
   EXPECT_TRUE(helper.GenerateBySCsText(scsData));
 
   ScAddr const nodeTupleAddr = m_ctx->SearchElementBySystemIdentifier("sc_node_tuple");
@@ -325,6 +325,29 @@ TEST_F(SCsHelperTest, GenerateBySCs_BaseArcBetweenElementTypesWithinStructure)
 
   EXPECT_EQ(m_ctx->GetElementEdgesAndOutgoingArcsCount(structureAddr), 2u);
   EXPECT_TRUE(m_ctx->CheckConnector(structureAddr, nodeClassAddr, ScType::ConstPermPosArc));
+}
+
+TEST_F(SCsHelperTest, GenerateBySCs_ArcToElementTypeFromIncomtableElementTypesWithinStructure)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "structure = [* sc_node_tuple -> sc_node_class;; *];;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
+
+TEST_F(SCsHelperTest, GenerateBySCs_ContourWithImplicitlySpecifiedElementTypeSystemIdentifier)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "sc_node_class = [* sc_node -> sc_node_class;; *];;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
+
+TEST_F(SCsHelperTest, DISABLED_GenerateBySCs_ContourWithExplicitlySpecifiedElementTypeSystemIdentifier)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = 
+    "..contour = [* sc_node -> sc_node_class;; *];;"
+    "..contour => nrel_system_identifier: [sc_node_class];;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
 }
 
 TEST_F(SCsHelperTest, GenerateBySCs_NotBaseArcBetweenElementTypesWithinStructure)

--- a/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
@@ -197,6 +197,65 @@ TEST_F(SCsHelperTest, GenerateBySCs_SingleNode)
   EXPECT_FALSE(m_ctx->CheckConnector(nodeClass, node, ScType::ConstPermPosArc));
 }
 
+TEST_F(SCsHelperTest, GenerateBySCs_ElementTypes)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "sc_node_class"
+    "-> class1;"
+    "-> rrel_1: class2;;"
+    "class3"
+    "-> sc_node_class;;"
+    "class4"
+    "-> rrel_1: sc_node_class;;"
+    "sc_node_class "
+    "_-> class5;"
+    "_-> _class6;"
+    "_-> rrel_3: class7;"
+    "_-> rrel_4:: _class8;;";
+
+  EXPECT_TRUE(helper.GenerateBySCsText(scsData));
+
+  ScAddr const & nodeClass = m_ctx->SearchElementBySystemIdentifier("sc_node_class");
+  ScAddr const & class1 = m_ctx->SearchElementBySystemIdentifier("class1");
+  EXPECT_EQ(m_ctx->GetElementType(class1), ScType::ConstNodeClass);
+  EXPECT_FALSE(m_ctx->CheckConnector(nodeClass, class1, ScType::ConstPermPosArc));
+
+  ScAddr const & class2 = m_ctx->SearchElementBySystemIdentifier("class2");
+  EXPECT_EQ(m_ctx->GetElementType(class2), ScType::ConstNodeClass);
+  EXPECT_FALSE(m_ctx->CheckConnector(nodeClass, class2, ScType::ConstPermPosArc));
+
+  ScAddr const & class3 = m_ctx->SearchElementBySystemIdentifier("class3");
+  EXPECT_EQ(m_ctx->GetElementType(class3), ScType::ConstNode);
+  EXPECT_TRUE(m_ctx->CheckConnector(class3, nodeClass, ScType::ConstPermPosArc));
+
+  ScAddr const & class4 = m_ctx->SearchElementBySystemIdentifier("class4");
+  EXPECT_EQ(m_ctx->GetElementType(class4), ScType::ConstNode);
+  EXPECT_TRUE(
+      m_ctx->CreateIterator5(class4, ScType::ConstPermPosArc, nodeClass, ScType::ConstPermPosArc, ScKeynodes::rrel_1)
+          ->Next());
+
+  ScAddr const & class5 = m_ctx->SearchElementBySystemIdentifier("class5");
+  EXPECT_EQ(m_ctx->GetElementType(class5), ScType::ConstNode);
+  EXPECT_TRUE(m_ctx->CheckConnector(nodeClass, class5, ScType::VarPermPosArc));
+
+  ScAddr const & class6 = m_ctx->SearchElementBySystemIdentifier("_class6");
+  EXPECT_EQ(m_ctx->GetElementType(class6), ScType::VarNode);
+  EXPECT_TRUE(m_ctx->CheckConnector(nodeClass, class6, ScType::VarPermPosArc));
+
+  ScAddr const & class7 = m_ctx->SearchElementBySystemIdentifier("class7");
+  EXPECT_EQ(m_ctx->GetElementType(class7), ScType::ConstNode);
+  EXPECT_TRUE(
+      m_ctx->CreateIterator5(nodeClass, ScType::VarPermPosArc, class7, ScType::ConstPermPosArc, ScKeynodes::rrel_3)
+          ->Next());
+
+  ScAddr const & class8 = m_ctx->SearchElementBySystemIdentifier("_class8");
+  ScAddr const & rrel_4 = m_ctx->SearchElementBySystemIdentifier("rrel_4");
+  EXPECT_EQ(m_ctx->GetElementType(class8), ScType::VarNode);
+  EXPECT_TRUE(
+      m_ctx->CreateIterator5(nodeClass, ScType::VarPermPosArc, class8, ScType::VarPermPosArc, rrel_4)
+          ->Next());
+}
+
 TEST_F(SCsHelperTest, GenerateBySCs_Visibility_System)
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());

--- a/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
@@ -350,6 +350,55 @@ TEST_F(SCsHelperTest, DISABLED_GenerateBySCs_ContourWithExplicitlySpecifiedEleme
   EXPECT_FALSE(helper.GenerateBySCsText(scsData));
 }
 
+TEST_F(SCsHelperTest, GenerateBySCs_ConnectorBelongsToNodeType)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "..contour = [* sc_node_tuple -> (sc_node_class => sc_node_tuple);; *];;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
+
+TEST_F(SCsHelperTest, GenerateBySCs_NodeBelongsToConnectorsType)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "..contour = [* sc_main_arc -> ..node;; *];;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
+
+TEST_F(SCsHelperTest, GenerateBySCs_NodeBelongsToTwoIncompatibleType)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "..contour = [* sc_node_class -> ..node;; sc_node_tuple -> ..node;; *];;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
+
+TEST_F(SCsHelperTest, GenerateBySCs_MembershipArcBelongsToCommonArcsType)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "..contour = [* sc_common_arc -> (... -> ...);; *];;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
+
+TEST_F(SCsHelperTest, GenerateBySCs_MembershipArcBelongsToCommonEdgesType)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "..contour = [* sc_common_edge -> (... -> ...);; *];;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
+
+TEST_F(SCsHelperTest, GenerateBySCs_CommonArcBelongsToMembershipArcsType)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "..contour = [* sc_main_arc -> (... => ...);; *];;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
+
+TEST_F(SCsHelperTest, GenerateBySCs_CommonEdgeBelongsToMembershipArcsType)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "..contour = [* sc_main_arc -> (... <=> ...);; *];;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
+
 TEST_F(SCsHelperTest, GenerateBySCs_NotBaseArcBetweenElementTypesWithinStructure)
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());

--- a/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
@@ -316,9 +316,9 @@ TEST_F(SCsHelperTest, GenerateBySCs_BaseArcBetweenElementTypesWithinStructure)
   std::string const scsData = "structure = [* sc_node -> sc_node_class;; *];;";
   EXPECT_TRUE(helper.GenerateBySCsText(scsData));
 
-  ScAddr const nodeTupleAddr = m_ctx->SearchElementBySystemIdentifier("sc_node_tuple");
+  ScAddr const nodeAddr = m_ctx->SearchElementBySystemIdentifier("sc_node");
   ScAddr const nodeClassAddr = m_ctx->SearchElementBySystemIdentifier("sc_node_class");
-  EXPECT_FALSE(m_ctx->CheckConnector(nodeTupleAddr, nodeClassAddr, ScType::ConstPermPosArc));
+  EXPECT_FALSE(m_ctx->CheckConnector(nodeAddr, nodeClassAddr, ScType::ConstPermPosArc));
 
   ScAddr const & structureAddr = m_ctx->SearchElementBySystemIdentifier("structure");
   EXPECT_TRUE(structureAddr.IsValid());
@@ -327,7 +327,7 @@ TEST_F(SCsHelperTest, GenerateBySCs_BaseArcBetweenElementTypesWithinStructure)
   EXPECT_TRUE(m_ctx->CheckConnector(structureAddr, nodeClassAddr, ScType::ConstPermPosArc));
 }
 
-TEST_F(SCsHelperTest, GenerateBySCs_ArcToElementTypeFromIncomtableElementTypesWithinStructure)
+TEST_F(SCsHelperTest, GenerateBySCs_ArcToElementTypeFromIncompatibleElementTypesWithinStructure)
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
   std::string const scsData = "structure = [* sc_node_tuple -> sc_node_class;; *];;";

--- a/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
@@ -215,14 +215,14 @@ TEST_F(SCsHelperTest, GenerateBySCs_NotConstPermPosArcFromElementType)
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
   std::string const scsData = "sc_node_class => ..relation: class1;;";
-  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+  EXPECT_TRUE(helper.GenerateBySCsText(scsData));
 }
 
 TEST_F(SCsHelperTest, GenerateBySCs_ArcToElementType)
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
   std::string const scsData = "set -> sc_node_class;;";
-  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+  EXPECT_TRUE(helper.GenerateBySCsText(scsData));
 }
 
 TEST_F(SCsHelperTest, GenerateBySCs_ElementWithTypeWithinStructure)
@@ -243,14 +243,14 @@ TEST_F(SCsHelperTest, GenerateBySCs_NotConstPermPosArcFromElementTypeWithinStruc
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
   std::string const scsData = "structure = [* sc_node_class => ..relation: class1;; *];;";
-  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+  EXPECT_TRUE(helper.GenerateBySCsText(scsData));
 }
 
 TEST_F(SCsHelperTest, GenerateBySCs_ArcToElementTypeWithinStructure)
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
   std::string const scsData = "structure = [* set -> sc_node_class;; *];;";
-  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+  EXPECT_TRUE(helper.GenerateBySCsText(scsData));
 }
 
 TEST_F(SCsHelperTest, GenerateBySCs_Visibility_System)

--- a/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
@@ -399,6 +399,30 @@ TEST_F(SCsHelperTest, GenerateBySCs_CommonEdgeBelongsToMembershipArcsType)
   EXPECT_FALSE(helper.GenerateBySCsText(scsData));
 }
 
+TEST_F(SCsHelperTest, GenerateBySCs_VarPermPosArcBelongsToMembershipArcsType)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "structure = [* sc_membership_arc -> (node1 _-> node2);; *];;";
+  EXPECT_TRUE(helper.GenerateBySCsText(scsData));
+
+  ScAddr const membershipArcAddr = m_ctx->SearchElementBySystemIdentifier("sc_membership_arc");
+  ScAddr const node1Addr = m_ctx->SearchElementBySystemIdentifier("node1");
+  ScAddr const node2Addr = m_ctx->SearchElementBySystemIdentifier("node2");
+  ScIterator3Ptr it3 = m_ctx->CreateIterator3(node1Addr, ScType::VarPermPosArc, node2Addr);
+  EXPECT_TRUE(it3->Next());
+  ScAddr const arcAddr = it3->Get(1);
+  it3 = m_ctx->CreateIterator3(membershipArcAddr, ScType::ConstPermPosArc, arcAddr);
+  EXPECT_FALSE(it3->Next());
+
+  ScAddr const & structureAddr = m_ctx->SearchElementBySystemIdentifier("structure");
+  EXPECT_TRUE(structureAddr.IsValid());
+
+  EXPECT_EQ(m_ctx->GetElementEdgesAndOutgoingArcsCount(structureAddr), 4);
+  EXPECT_TRUE(m_ctx->CheckConnector(structureAddr, node1Addr, ScType::ConstPermPosArc));
+  EXPECT_TRUE(m_ctx->CheckConnector(structureAddr, arcAddr, ScType::ConstPermPosArc));
+  EXPECT_TRUE(m_ctx->CheckConnector(structureAddr, node2Addr, ScType::ConstPermPosArc));
+}
+
 TEST_F(SCsHelperTest, GenerateBySCs_NotBaseArcBetweenElementTypesWithinStructure)
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());

--- a/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
@@ -423,6 +423,13 @@ TEST_F(SCsHelperTest, GenerateBySCs_VarPermPosArcBelongsToMembershipArcsType)
   EXPECT_TRUE(m_ctx->CheckConnector(structureAddr, node2Addr, ScType::ConstPermPosArc));
 }
 
+TEST_F(SCsHelperTest, GenerateBySCs_VarPermPosArcBelongsToMainArcsType)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "structure = [* sc_main_arc -> (node1 _-> node2);; *];;";
+  EXPECT_FALSE(helper.GenerateBySCsText(scsData));
+}
+
 TEST_F(SCsHelperTest, GenerateBySCs_NotBaseArcBetweenElementTypesWithinStructure)
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());

--- a/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/scs-helper/test_scs_helper.cpp
@@ -423,6 +423,30 @@ TEST_F(SCsHelperTest, GenerateBySCs_VarPermPosArcBelongsToMembershipArcsType)
   EXPECT_TRUE(m_ctx->CheckConnector(structureAddr, node2Addr, ScType::ConstPermPosArc));
 }
 
+TEST_F(SCsHelperTest, GenerateBySCs_MembershipArcBelongsToMainArcsType)
+{
+  SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());
+  std::string const scsData = "structure = [* sc_main_arc -> (node1 ?.?> node2);; *];;";
+  EXPECT_TRUE(helper.GenerateBySCsText(scsData));
+
+  ScAddr const membershipArcAddr = m_ctx->SearchElementBySystemIdentifier("sc_main_arc");
+  ScAddr const node1Addr = m_ctx->SearchElementBySystemIdentifier("node1");
+  ScAddr const node2Addr = m_ctx->SearchElementBySystemIdentifier("node2");
+  ScIterator3Ptr it3 = m_ctx->CreateIterator3(node1Addr, ScType::ConstPermPosArc, node2Addr);
+  EXPECT_TRUE(it3->Next());
+  ScAddr const arcAddr = it3->Get(1);
+  it3 = m_ctx->CreateIterator3(membershipArcAddr, ScType::ConstPermPosArc, arcAddr);
+  EXPECT_FALSE(it3->Next());
+
+  ScAddr const & structureAddr = m_ctx->SearchElementBySystemIdentifier("structure");
+  EXPECT_TRUE(structureAddr.IsValid());
+
+  EXPECT_EQ(m_ctx->GetElementEdgesAndOutgoingArcsCount(structureAddr), 4);
+  EXPECT_TRUE(m_ctx->CheckConnector(structureAddr, node1Addr, ScType::ConstPermPosArc));
+  EXPECT_TRUE(m_ctx->CheckConnector(structureAddr, arcAddr, ScType::ConstPermPosArc));
+  EXPECT_TRUE(m_ctx->CheckConnector(structureAddr, node2Addr, ScType::ConstPermPosArc));
+}
+
 TEST_F(SCsHelperTest, GenerateBySCs_VarPermPosArcBelongsToMainArcsType)
 {
   SCsHelper helper(*m_ctx, std::make_shared<DummyFileInterface>());

--- a/sc-memory/sc-memory/tests/sc-memory/units/templates/test_sc_templates_scs.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/templates/test_sc_templates_scs.cpp
@@ -21,11 +21,18 @@ TEST_F(ScTemplateSCsTest, BuildSuccessful)
   m_ctx->BuildTemplate(templ, data);
 }
 
-TEST_F(ScTemplateSCsTest, BuildFail)
+TEST_F(ScTemplateSCsTest, InvalidSCs)
 {
   ScTemplate templ;
   sc_char const * data = "_a _-> b";
   EXPECT_THROW(m_ctx->BuildTemplate(templ, data), utils::ExceptionParseError);
+}
+
+TEST_F(ScTemplateSCsTest, ElementNotFound)
+{
+  ScTemplate templ;
+  sc_char const * data = "_a _-> b;;";
+  EXPECT_THROW(m_ctx->BuildTemplate(templ, data), utils::ExceptionInvalidState);
 }
 
 TEST_F(ScTemplateSCsTest, GenBuildSearch)

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_alias.cpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_alias.cpp
@@ -45,9 +45,9 @@ TEST(scs_alias, recursive_assigns)
   EXPECT_TRUE(parser.Parse(data));
 
   auto const & triples = parser.GetParsedTriples();
-  EXPECT_EQ(triples.size(), 1u);
+  EXPECT_EQ(triples.size(), 2u);
 
-  auto const t = triples.front();
+  auto const t = triples.back();
   auto const & src = parser.GetParsedElement(t.m_source);
   auto const & arcAddr = parser.GetParsedElement(t.m_connector);
   auto const & trg = parser.GetParsedElement(t.m_target);
@@ -71,10 +71,10 @@ TEST(scs_alias, reassign)
   EXPECT_TRUE(parser.Parse(data));
 
   auto const & triples = parser.GetParsedTriples();
-  EXPECT_EQ(triples.size(), 2u);
+  EXPECT_EQ(triples.size(), 3u);
 
   {
-    auto const & t = triples[0];
+    auto const & t = triples[1];
 
     auto const & src = parser.GetParsedElement(t.m_source);
     auto const & arcAddr = parser.GetParsedElement(t.m_connector);
@@ -90,7 +90,7 @@ TEST(scs_alias, reassign)
   }
 
   {
-    auto const & t = triples[1];
+    auto const & t = triples[2];
 
     auto const & src = parser.GetParsedElement(t.m_source);
     auto const & arcAddr = parser.GetParsedElement(t.m_connector);

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_alias.cpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_alias.cpp
@@ -47,19 +47,37 @@ TEST(scs_alias, recursive_assigns)
   auto const & triples = parser.GetParsedTriples();
   EXPECT_EQ(triples.size(), 2u);
 
-  auto const t = triples.back();
-  auto const & src = parser.GetParsedElement(t.m_source);
-  auto const & arcAddr = parser.GetParsedElement(t.m_connector);
-  auto const & trg = parser.GetParsedElement(t.m_target);
+  {
+    auto const t = triples.front();
+    auto source = parser.GetParsedElement(t.m_source);
+    auto connector = parser.GetParsedElement(t.m_connector);
+    auto target = parser.GetParsedElement(t.m_target);
 
-  EXPECT_EQ(src.GetIdtf(), "_y");
-  EXPECT_TRUE(src.GetType().IsNode());
-  EXPECT_TRUE(src.GetType().IsVar());
+    EXPECT_EQ(source.GetIdtf(), "sc_node_tuple");
+    EXPECT_TRUE(source.GetType().IsNode());
+    EXPECT_TRUE(source.GetType().IsConst());
 
-  EXPECT_EQ(arcAddr.GetType(), ScType::ConstPermNegArc);
+    EXPECT_EQ(connector.GetType(), ScType::ConstPermPosArc);
 
-  EXPECT_EQ(trg.GetIdtf(), "x");
-  EXPECT_EQ(trg.GetType(), ScType::ConstNodeTuple);
+    EXPECT_EQ(target.GetIdtf(), "x");
+    EXPECT_EQ(target.GetType(), ScType::ConstNodeTuple);
+  }
+
+  {
+    auto const t = triples.back();
+    auto source = parser.GetParsedElement(t.m_source);
+    auto connector = parser.GetParsedElement(t.m_connector);
+    auto target = parser.GetParsedElement(t.m_target);
+
+    EXPECT_EQ(source.GetIdtf(), "_y");
+    EXPECT_TRUE(source.GetType().IsNode());
+    EXPECT_TRUE(source.GetType().IsVar());
+
+    EXPECT_EQ(connector.GetType(), ScType::ConstPermNegArc);
+
+    EXPECT_EQ(target.GetIdtf(), "x");
+    EXPECT_EQ(target.GetType(), ScType::ConstNodeTuple);
+  }
 }
 
 TEST(scs_alias, reassign)
@@ -74,34 +92,50 @@ TEST(scs_alias, reassign)
   EXPECT_EQ(triples.size(), 3u);
 
   {
+    auto const & t = triples[0];
+
+    auto const & source = parser.GetParsedElement(t.m_source);
+    auto const & connector = parser.GetParsedElement(t.m_connector);
+    auto const & target = parser.GetParsedElement(t.m_target);
+
+    EXPECT_EQ(source.GetIdtf(), "sc_node_struct");
+    EXPECT_EQ(source.GetType(), ScType::ConstNode);
+
+    EXPECT_EQ(connector.GetType(), ScType::ConstPermPosArc);
+
+    EXPECT_EQ(target.GetIdtf(), "_x");
+    EXPECT_EQ(target.GetType(), ScType::VarNodeStructure);
+  }
+
+  {
     auto const & t = triples[1];
 
-    auto const & src = parser.GetParsedElement(t.m_source);
-    auto const & arcAddr = parser.GetParsedElement(t.m_connector);
-    auto const & trg = parser.GetParsedElement(t.m_target);
+    auto const & source = parser.GetParsedElement(t.m_source);
+    auto const & connector = parser.GetParsedElement(t.m_connector);
+    auto const & target = parser.GetParsedElement(t.m_target);
 
-    EXPECT_EQ(src.GetIdtf(), "y");
-    EXPECT_EQ(src.GetType(), ScType::ConstNode);
+    EXPECT_EQ(source.GetIdtf(), "y");
+    EXPECT_EQ(source.GetType(), ScType::ConstNode);
 
-    EXPECT_EQ(arcAddr.GetType(), ScType::VarFuzArc);
+    EXPECT_EQ(connector.GetType(), ScType::VarFuzArc);
 
-    EXPECT_EQ(trg.GetIdtf(), "_x");
-    EXPECT_EQ(trg.GetType(), ScType::VarNodeStructure);
+    EXPECT_EQ(target.GetIdtf(), "_x");
+    EXPECT_EQ(target.GetType(), ScType::VarNodeStructure);
   }
 
   {
     auto const & t = triples[2];
 
-    auto const & src = parser.GetParsedElement(t.m_source);
-    auto const & arcAddr = parser.GetParsedElement(t.m_connector);
-    auto const & trg = parser.GetParsedElement(t.m_target);
+    auto const & source = parser.GetParsedElement(t.m_source);
+    auto const & connector = parser.GetParsedElement(t.m_connector);
+    auto const & target = parser.GetParsedElement(t.m_target);
 
-    EXPECT_EQ(src.GetIdtf(), "z");
-    EXPECT_EQ(src.GetType(), ScType::ConstNode);
+    EXPECT_EQ(source.GetIdtf(), "z");
+    EXPECT_EQ(source.GetType(), ScType::ConstNode);
 
-    EXPECT_EQ(arcAddr.GetType(), ScType::VarActualTempPosArc);
+    EXPECT_EQ(connector.GetType(), ScType::VarActualTempPosArc);
 
-    EXPECT_EQ(trg.GetType(), ScType::VarNodeLink);
+    EXPECT_EQ(target.GetType(), ScType::VarNodeLink);
   }
 }
 

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_alias.cpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_alias.cpp
@@ -1,8 +1,8 @@
 /*
-* This source file is part of an OSTIS project. For the latest info, see http://ostis.net
-* Distributed under the MIT License
-* (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
-*/
+ * This source file is part of an OSTIS project. For the latest info, see http://ostis.net
+ * Distributed under the MIT License
+ * (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
+ */
 
 #include <gtest/gtest.h>
 
@@ -10,7 +10,6 @@
 
 TEST(scs_alias, assign)
 {
-
   std::string const data = "@alias = [];; x ~> @alias;;";
 
   scs::Parser parser;

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_common.cpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_common.cpp
@@ -177,9 +177,9 @@ public:
 TEST(scs_common, SCsNodeKeynodes)
 {
   std::vector<ScType> const & nodeTypes = {
-    ScType::NodeRole,
     ScType::Node,
     ScType::NodeClass,
+    ScType::NodeRole,
     ScType::NodeNonRole,
     ScType::NodeTuple,
     ScType::NodeStructure,
@@ -200,11 +200,12 @@ TEST(scs_common, SCsNodeKeynodes)
   EXPECT_TRUE(parser.Parse(stream.str()));
 
   auto const & triples = parser.GetParsedTriples();
-  EXPECT_EQ(triples.size(), nodeTypes.size());
+  EXPECT_EQ(triples.size(), nodeTypes.size() * 3);
 
   auto const GetSourceNodeType = [&triples, &parser](size_t index) -> ScType
   {
     EXPECT_TRUE(index < triples.size());
+    std::cout << std::string(parser.GetParsedElement(triples[index].m_source).GetType()) << std::endl;
     return parser.GetParsedElement(triples[index].m_source).GetType();
   };
 
@@ -214,10 +215,10 @@ TEST(scs_common, SCsNodeKeynodes)
     return parser.GetParsedElement(triples[index].m_target).GetType();
   };
 
-  for (size_t i = 0; i < nodeTypes.size(); ++i)
+  for (size_t i = 0, j = 0; i < nodeTypes.size(); i += 3, ++j)
   {
-    EXPECT_EQ(GetSourceNodeType(i), TestScType(nodeTypes[i]).BitOr(ScType::Var));
-    EXPECT_EQ(GetTargetNodeType(i), TestScType(nodeTypes[i]).BitOr(ScType::Const));
+    EXPECT_EQ(GetSourceNodeType(i), TestScType(nodeTypes[j]).BitOr(ScType::Var));
+    EXPECT_EQ(GetTargetNodeType(i), TestScType(nodeTypes[j]).BitOr(ScType::Const));
   }
 }
 
@@ -296,13 +297,13 @@ TEST(scs_common, DeprecatedSCsKeynodes)
   EXPECT_TRUE(parser.Parse(data));
 
   auto const & triples = parser.GetParsedTriples();
-  EXPECT_EQ(triples.size(), 3u);
+  EXPECT_EQ(triples.size(), 7u);
 
   EXPECT_EQ(parser.GetParsedElement(triples[0].m_source).GetType(), ScType::ConstNodeStructure);
   EXPECT_EQ(parser.GetParsedElement(triples[0].m_target).GetType(), ScType::ConstNodeClass);
-  EXPECT_EQ(parser.GetParsedElement(triples[1].m_source).GetType(), ScType::ConstNodeStructure);
-  EXPECT_EQ(parser.GetParsedElement(triples[1].m_target).GetType(), ScType::ConstNodeTuple);
-  EXPECT_EQ(parser.GetParsedElement(triples[2].m_source).GetType(), ScType::ConstNodeNonRole);
+  EXPECT_EQ(parser.GetParsedElement(triples[2].m_source).GetType(), ScType::ConstNodeStructure);
+  EXPECT_EQ(parser.GetParsedElement(triples[2].m_target).GetType(), ScType::ConstNodeTuple);
+  EXPECT_EQ(parser.GetParsedElement(triples[5].m_source).GetType(), ScType::ConstNodeNonRole);
 }
 
 TEST(scs_common, DirectConnectors)

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_common.cpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_common.cpp
@@ -1,15 +1,14 @@
 /*
-* This source file is part of an OSTIS project. For the latest info, see http://ostis.net
-* Distributed under the MIT License
-* (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
-*/
+ * This source file is part of an OSTIS project. For the latest info, see http://ostis.net
+ * Distributed under the MIT License
+ * (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
+ */
 
 #include <gtest/gtest.h>
 
 #include <sstream>
 
 #include "test_scs_utils.hpp"
-
 
 TEST(scs_common, ElementHandle)
 {
@@ -177,23 +176,29 @@ public:
 TEST(scs_common, SCsNodeKeynodes)
 {
   std::vector<ScType> const & nodeTypes = {
-    ScType::Node,
-    ScType::NodeClass,
-    ScType::NodeRole,
-    ScType::NodeNonRole,
-    ScType::NodeTuple,
-    ScType::NodeStructure,
-    ScType::NodeSuperclass,
-    ScType::NodeLink,
-    ScType::NodeLinkClass,
+      ScType::Node,
+      ScType::NodeClass,
+      ScType::NodeRole,
+      ScType::NodeNonRole,
+      ScType::NodeTuple,
+      ScType::NodeStructure,
+      ScType::NodeSuperclass,
+      ScType::NodeLink,
+      ScType::NodeLinkClass,
   };
 
   std::stringstream stream;
   for (ScType const & nodeType : nodeTypes)
   {
-    stream << ".._node_" << std::string(nodeType) << " -> " << "..node_" << std::string(nodeType) << ";;\n" << std::endl;
-    stream << nodeType.GetSCsElementKeynode() << " -> " << "..node_" << std::string(nodeType) << ";;\n" << std::endl;
-    stream << nodeType.GetSCsElementKeynode() << " -> " << ".._node_" << std::string(nodeType) << ";;\n" << std::endl;
+    stream << ".._node_" << std::string(nodeType) << " -> "
+           << "..node_" << std::string(nodeType) << ";;\n"
+           << std::endl;
+    stream << nodeType.GetSCsElementKeynode() << " -> "
+           << "..node_" << std::string(nodeType) << ";;\n"
+           << std::endl;
+    stream << nodeType.GetSCsElementKeynode() << " -> "
+           << ".._node_" << std::string(nodeType) << ";;\n"
+           << std::endl;
   }
 
   scs::Parser parser;
@@ -223,11 +228,7 @@ TEST(scs_common, SCsNodeKeynodes)
 
 TEST(scs_common, SCsMembershipArcKeynodes)
 {
-  std::vector<ScType> const & connectorTypes = {
-    ScType::MembershipArc,
-    ScType::CommonArc,
-    ScType::CommonEdge
-  };
+  std::vector<ScType> const & connectorTypes = {ScType::MembershipArc, ScType::CommonArc, ScType::CommonEdge};
 
   std::stringstream stream;
   for (ScType const & connectorType : connectorTypes)
@@ -240,12 +241,14 @@ TEST(scs_common, SCsMembershipArcKeynodes)
     else if (connectorType.IsCommonEdge())
       connectorTypeToExtend = ScType::CommonEdge;
 
-    stream << connectorType.GetSCsElementKeynode() << " -> " 
-      << "(... " << connectorTypeToExtend.GetDirectSCsConnector() << " ...);;" << std::endl;
     stream << connectorType.GetSCsElementKeynode() << " -> "
-      << "(... " << TestScType(connectorTypeToExtend).BitOr(ScType::Const).GetDirectSCsConnector() << " ...);;" << std::endl;
+           << "(... " << connectorTypeToExtend.GetDirectSCsConnector() << " ...);;" << std::endl;
     stream << connectorType.GetSCsElementKeynode() << " -> "
-      << "(... " << TestScType(connectorTypeToExtend).BitOr(ScType::Var).GetDirectSCsConnector() << " ...);;" << std::endl;
+           << "(... " << TestScType(connectorTypeToExtend).BitOr(ScType::Const).GetDirectSCsConnector() << " ...);;"
+           << std::endl;
+    stream << connectorType.GetSCsElementKeynode() << " -> "
+           << "(... " << TestScType(connectorTypeToExtend).BitOr(ScType::Var).GetDirectSCsConnector() << " ...);;"
+           << std::endl;
   }
 
   scs::Parser parser;
@@ -314,9 +317,11 @@ TEST(scs_common, LinkAssigns)
 
   EXPECT_TRUE(parser.Parse(data));
 
-  parser.ForEachParsedElement([](scs::ParsedElement const & element) -> void {
-    EXPECT_EQ(element.GetType() & ScType::VarNodeLink, ScType::VarNodeLink);
-  });
+  parser.ForEachParsedElement(
+      [](scs::ParsedElement const & element) -> void
+      {
+        EXPECT_EQ(element.GetType() & ScType::VarNodeLink, ScType::VarNodeLink);
+      });
 
   EXPECT_EQ(parser.GetParsedElement(scs::ElementHandle(0)).GetValue(), "file://data.txt");
   EXPECT_TRUE(parser.GetParsedElement(scs::ElementHandle(0)).IsURL());
@@ -337,7 +342,9 @@ TEST(scs_common, LinkAssigns)
 
 TEST(scs_common, DeprecatedSCsKeynodes)
 {
-  std::string const data = "a <- c;; a <- sc_node_not_relation;; b <- c;; b <- sc_node_not_binary_tuple;; c <- sc_node_struct;; a <- d;; d <- sc_node_norole_relation;;";
+  std::string const data =
+      "a <- c;; a <- sc_node_not_relation;; b <- c;; b <- sc_node_not_binary_tuple;; c <- sc_node_struct;; a <- d;; d "
+      "<- sc_node_norole_relation;;";
   scs::Parser parser;
 
   EXPECT_TRUE(parser.Parse(data));
@@ -417,7 +424,8 @@ TEST(scs_common, ReversedConnectors)
   auto const & triples = parser.GetParsedTriples();
   EXPECT_EQ(triples.size(), 8u);
   {
-    auto const CheckEdgeType = [&triples, &parser](size_t index, ScType type) -> bool {
+    auto const CheckEdgeType = [&triples, &parser](size_t index, ScType type) -> bool
+    {
       EXPECT_TRUE(index < triples.size());
       return (parser.GetParsedElement(triples[index].m_connector).GetType() == type);
     };
@@ -439,8 +447,7 @@ TEST(scs_common, VarConnectorsAndNodes)
       "x"
       "<-_y; <-_ y1; <- _y2; <-_ _y3;;";
 
-  std::string const errorData =
-      "x <- _ y3;;";
+  std::string const errorData = "x <- _ y3;;";
 
   scs::Parser parser;
 
@@ -450,7 +457,8 @@ TEST(scs_common, VarConnectorsAndNodes)
   auto const & triples = parser.GetParsedTriples();
   EXPECT_EQ(triples.size(), 4u);
   {
-    auto const CheckEdgeType = [&triples, &parser](size_t index, ScType type) -> bool {
+    auto const CheckEdgeType = [&triples, &parser](size_t index, ScType type) -> bool
+    {
       EXPECT_TRUE(index < triples.size());
       return (parser.GetParsedElement(triples[index].m_connector).GetType() == type);
     };

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_common.cpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_common.cpp
@@ -224,7 +224,6 @@ TEST(scs_common, SCsNodeKeynodes)
 TEST(scs_common, SCsMembershipArcKeynodes)
 {
   std::vector<ScType> const & connectorTypes = {
-    ScType::ConstPermPosArc,
     ScType::MembershipArc,
     ScType::CommonArc,
     ScType::CommonEdge

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_common.cpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_common.cpp
@@ -205,7 +205,6 @@ TEST(scs_common, SCsNodeKeynodes)
   auto const GetSourceNodeType = [&triples, &parser](size_t index) -> ScType
   {
     EXPECT_TRUE(index < triples.size());
-    std::cout << std::string(parser.GetParsedElement(triples[index].m_source).GetType()) << std::endl;
     return parser.GetParsedElement(triples[index].m_source).GetType();
   };
 
@@ -215,7 +214,7 @@ TEST(scs_common, SCsNodeKeynodes)
     return parser.GetParsedElement(triples[index].m_target).GetType();
   };
 
-  for (size_t i = 0, j = 0; i < nodeTypes.size(); i += 3, ++j)
+  for (size_t i = 0, j = 0; j < nodeTypes.size(); i += 3, ++j)
   {
     EXPECT_EQ(GetSourceNodeType(i), TestScType(nodeTypes[j]).BitOr(ScType::Var));
     EXPECT_EQ(GetTargetNodeType(i), TestScType(nodeTypes[j]).BitOr(ScType::Const));

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_common.cpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_common.cpp
@@ -21,7 +21,7 @@ TEST(scs_common, ElementHandle)
   EXPECT_TRUE(handle_ok.IsValid());
   EXPECT_FALSE(handle_ok.IsLocal());
 
-  scs::ElementHandle handle_local(0, true);
+  scs::ElementHandle handle_local(0, scs::Visibility::Local);
   EXPECT_TRUE(handle_local.IsValid());
   EXPECT_TRUE(handle_local.IsLocal());
 }

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_level_1.cpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_level_1.cpp
@@ -1,8 +1,8 @@
 /*
-* This source file is part of an OSTIS project. For the latest info, see http://ostis.net
-* Distributed under the MIT License
-* (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
-*/
+ * This source file is part of an OSTIS project. For the latest info, see http://ostis.net
+ * Distributed under the MIT License
+ * (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
+ */
 
 #include <gtest/gtest.h>
 

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_level_2.cpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_level_2.cpp
@@ -1,8 +1,8 @@
 /*
-* This source file is part of an OSTIS project. For the latest info, see http://ostis.net
-* Distributed under the MIT License
-* (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
-*/
+ * This source file is part of an OSTIS project. For the latest info, see http://ostis.net
+ * Distributed under the MIT License
+ * (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
+ */
 
 #include <gtest/gtest.h>
 
@@ -16,18 +16,11 @@ TEST(scs_level_2, simple_1)
 
   EXPECT_TRUE(parser.Parse(data));
   TripleTester tester(parser);
-  tester({
-           {
-             { ScType::ConstNode, "c" },
-             { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-             { ScType::ConstNode, "b" }
-           },
-           {
-             { ScType::ConstNode, "a" },
-             { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-             { ScType::ConstPermPosArc, "", scs::Visibility::Local }
-           }
-         });
+  tester(
+      {{{ScType::ConstNode, "c"}, {ScType::ConstPermPosArc, "", scs::Visibility::Local}, {ScType::ConstNode, "b"}},
+       {{ScType::ConstNode, "a"},
+        {ScType::ConstPermPosArc, "", scs::Visibility::Local},
+        {ScType::ConstPermPosArc, "", scs::Visibility::Local}}});
 
   auto const & triples = parser.GetParsedTriples();
   EXPECT_EQ(triples.size(), 2u);
@@ -41,18 +34,11 @@ TEST(scs_level_2, simple_2)
 
   EXPECT_TRUE(parser.Parse(data));
   TripleTester tester(parser);
-  tester({
-           {
-             { ScType::ConstNode, "a" },
-             { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-             { ScType::ConstNode, "b" }
-           },
-           {
-             { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-             { ScType::ConstCommonArc, "", scs::Visibility::Local },
-             { ScType::ConstNode, "c" }
-           }
-         });
+  tester(
+      {{{ScType::ConstNode, "a"}, {ScType::ConstPermPosArc, "", scs::Visibility::Local}, {ScType::ConstNode, "b"}},
+       {{ScType::ConstPermPosArc, "", scs::Visibility::Local},
+        {ScType::ConstCommonArc, "", scs::Visibility::Local},
+        {ScType::ConstNode, "c"}}});
 
   auto const & triples = parser.GetParsedTriples();
   EXPECT_EQ(triples.size(), 2u);
@@ -67,23 +53,14 @@ TEST(scs_level_2, simple_3)
 
   EXPECT_TRUE(parser.Parse(data));
   TripleTester tester(parser);
-  tester({
-      {
-          { ScType::ConstNode, "c" },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstNode, "d" }
-      },
-      {
-          { ScType::ConstNode, "b" },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstNode, "a" },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local }
-      }
-  });
+  tester(
+      {{{ScType::ConstNode, "c"}, {ScType::ConstPermPosArc, "", scs::Visibility::Local}, {ScType::ConstNode, "d"}},
+       {{ScType::ConstNode, "b"},
+        {ScType::ConstPermPosArc, "", scs::Visibility::Local},
+        {ScType::ConstPermPosArc, "", scs::Visibility::Local}},
+       {{ScType::ConstNode, "a"},
+        {ScType::ConstPermPosArc, "", scs::Visibility::Local},
+        {ScType::ConstPermPosArc, "", scs::Visibility::Local}}});
 
   auto const & triples = parser.GetParsedTriples();
   EXPECT_EQ(triples.size(), 3u);
@@ -101,33 +78,16 @@ TEST(scs_level_2, complex)
   EXPECT_TRUE(parser.Parse(data));
 
   TripleTester tester(parser);
-  tester({
-           {
-             { ScType::ConstNode, "b" },
-             { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-             { ScType::ConstNode, "c" }
-           },
-           {
-             { ScType::ConstNode, "a" },
-             { ScType::CommonEdge, "", scs::Visibility::Local },
-             { ScType::ConstPermPosArc, "", scs::Visibility::Local }
-           },
-           {
-             { ScType::ConstNode, "x" },
-             { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-             { ScType::ConstNode, "c" }
-           },
-           {
-             { ScType::ConstNode, "b" },
-             { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-             { ScType::ConstNode, "y" }
-           },
-           {
-             { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-             { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-             { ScType::ConstPermPosArc, "", scs::Visibility::Local }
-           }
-         });
+  tester(
+      {{{ScType::ConstNode, "b"}, {ScType::ConstPermPosArc, "", scs::Visibility::Local}, {ScType::ConstNode, "c"}},
+       {{ScType::ConstNode, "a"},
+        {ScType::CommonEdge, "", scs::Visibility::Local},
+        {ScType::ConstPermPosArc, "", scs::Visibility::Local}},
+       {{ScType::ConstNode, "x"}, {ScType::ConstPermPosArc, "", scs::Visibility::Local}, {ScType::ConstNode, "c"}},
+       {{ScType::ConstNode, "b"}, {ScType::ConstPermPosArc, "", scs::Visibility::Local}, {ScType::ConstNode, "y"}},
+       {{ScType::ConstPermPosArc, "", scs::Visibility::Local},
+        {ScType::ConstPermPosArc, "", scs::Visibility::Local},
+        {ScType::ConstPermPosArc, "", scs::Visibility::Local}}});
 
   auto const & triples = parser.GetParsedTriples();
   EXPECT_EQ(triples.size(), 5u);
@@ -151,66 +111,34 @@ TEST(scs_level_2, ordered_set)
 
   TripleTester tester(parser);
   tester({
-      {
-          { ScType::ConstNode, "b" },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstNode, "c" }
-      },
-      {
-          { ScType::ConstNode, "rrel_1" },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstNode, "b" },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstNode, "d" }
-      },
-      {
-          { ScType::ConstNode, "b" },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstNode, "e" }
-      },
-      {
-          { ScType::ConstNode, "b" },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstNode, "f" }
-      },
-      {
-          { ScType::ConstNode, "rrel_last" },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstCommonArc, "", scs::Visibility::Local },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstNode, "a" },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstCommonArc, "", scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstCommonArc, "", scs::Visibility::Local },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstNode, "a" },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstCommonArc, "", scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstCommonArc, "", scs::Visibility::Local },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstNode, "a" },
-          { ScType::ConstPermPosArc, "", scs::Visibility::Local },
-          { ScType::ConstCommonArc, "", scs::Visibility::Local }
-      },
+      {{ScType::ConstNode, "b"}, {ScType::ConstPermPosArc, "", scs::Visibility::Local}, {ScType::ConstNode, "c"}},
+      {{ScType::ConstNode, "rrel_1"},
+       {ScType::ConstPermPosArc, "", scs::Visibility::Local},
+       {ScType::ConstPermPosArc, "", scs::Visibility::Local}},
+      {{ScType::ConstNode, "b"}, {ScType::ConstPermPosArc, "", scs::Visibility::Local}, {ScType::ConstNode, "d"}},
+      {{ScType::ConstNode, "b"}, {ScType::ConstPermPosArc, "", scs::Visibility::Local}, {ScType::ConstNode, "e"}},
+      {{ScType::ConstNode, "b"}, {ScType::ConstPermPosArc, "", scs::Visibility::Local}, {ScType::ConstNode, "f"}},
+      {{ScType::ConstNode, "rrel_last"},
+       {ScType::ConstPermPosArc, "", scs::Visibility::Local},
+       {ScType::ConstPermPosArc, "", scs::Visibility::Local}},
+      {{ScType::ConstPermPosArc, "", scs::Visibility::Local},
+       {ScType::ConstCommonArc, "", scs::Visibility::Local},
+       {ScType::ConstPermPosArc, "", scs::Visibility::Local}},
+      {{ScType::ConstNode, "a"},
+       {ScType::ConstPermPosArc, "", scs::Visibility::Local},
+       {ScType::ConstCommonArc, "", scs::Visibility::Local}},
+      {{ScType::ConstPermPosArc, "", scs::Visibility::Local},
+       {ScType::ConstCommonArc, "", scs::Visibility::Local},
+       {ScType::ConstPermPosArc, "", scs::Visibility::Local}},
+      {{ScType::ConstNode, "a"},
+       {ScType::ConstPermPosArc, "", scs::Visibility::Local},
+       {ScType::ConstCommonArc, "", scs::Visibility::Local}},
+      {{ScType::ConstPermPosArc, "", scs::Visibility::Local},
+       {ScType::ConstCommonArc, "", scs::Visibility::Local},
+       {ScType::ConstPermPosArc, "", scs::Visibility::Local}},
+      {{ScType::ConstNode, "a"},
+       {ScType::ConstPermPosArc, "", scs::Visibility::Local},
+       {ScType::ConstCommonArc, "", scs::Visibility::Local}},
   });
 
   auto const & triples = parser.GetParsedTriples();
@@ -228,7 +156,6 @@ TEST(scs_level_2, ordered_set)
   EXPECT_EQ(triples[6].m_connector, triples[7].m_target);
   EXPECT_EQ(triples[4].m_connector, triples[5].m_target);
 }
-
 
 TEST(scs_level_2, unnamed)
 {

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_level_3.cpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_level_3.cpp
@@ -1,8 +1,8 @@
 /*
-* This source file is part of an OSTIS project. For the latest info, see http://ostis.net
-* Distributed under the MIT License
-* (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
-*/
+ * This source file is part of an OSTIS project. For the latest info, see http://ostis.net
+ * Distributed under the MIT License
+ * (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
+ */
 
 #include <gtest/gtest.h>
 
@@ -15,23 +15,14 @@ TEST(scs_level_3, simple_1)
 
   EXPECT_TRUE(parser.Parse(data));
   TripleTester tester(parser);
-  tester({
-           {
-             { ScType::ConstNode, "a" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstNode, "d" }
-           },
-           {
-             { ScType::ConstNode, "c" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local }
-           },
-           {
-             { ScType::VarNode, "_b" },
-             { ScType::VarPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local }
-           }
-         });
+  tester(
+      {{{ScType::ConstNode, "a"}, {ScType::ConstPermPosArc, scs::Visibility::Local}, {ScType::ConstNode, "d"}},
+       {{ScType::ConstNode, "c"},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local}},
+       {{ScType::VarNode, "_b"},
+        {ScType::VarPermPosArc, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local}}});
 
   auto const & triples = parser.GetParsedTriples();
   EXPECT_EQ(triples.size(), 3u);
@@ -48,33 +39,18 @@ TEST(scs_level_3, complex_1)
   EXPECT_TRUE(parser.Parse(data));
 
   TripleTester tester(parser);
-  tester({
-           {
-             { ScType::ConstNode, "d" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstNode, "a" }
-           },
-           {
-             { ScType::ConstNode, "f" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local }
-           },
-           {
-             { ScType::ConstNode, "c" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstNode, "d" }
-           },
-           {
-             { ScType::ConstNode, "b" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local }
-           },
-           {
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local }
-           }
-         });
+  tester(
+      {{{ScType::ConstNode, "d"}, {ScType::ConstPermPosArc, scs::Visibility::Local}, {ScType::ConstNode, "a"}},
+       {{ScType::ConstNode, "f"},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local}},
+       {{ScType::ConstNode, "c"}, {ScType::ConstPermPosArc, scs::Visibility::Local}, {ScType::ConstNode, "d"}},
+       {{ScType::ConstNode, "b"},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local}},
+       {{ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local}}});
 
   auto const & triples = parser.GetParsedTriples();
   EXPECT_EQ(triples.size(), 5u);
@@ -93,28 +69,17 @@ TEST(scs_level_3, complex_2)
   EXPECT_TRUE(parser.Parse(data));
 
   TripleTester tester(parser);
-  tester({
-           {
-             { ScType::ConstNode, "d" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstNode, "h"}
-           },
-           {
-             { ScType::ConstNode, "g" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local }
-           },
-           {
-             { ScType::ConstNode, "a" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local }
-           },
-           {
-             { ScType::ConstNode, "c" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local }
-           }
-         });
+  tester(
+      {{{ScType::ConstNode, "d"}, {ScType::ConstPermPosArc, scs::Visibility::Local}, {ScType::ConstNode, "h"}},
+       {{ScType::ConstNode, "g"},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local}},
+       {{ScType::ConstNode, "a"},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local}},
+       {{ScType::ConstNode, "c"},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local}}});
 
   auto const & triples = parser.GetParsedTriples();
   EXPECT_EQ(triples.size(), 4u);

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_level_4.cpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_level_4.cpp
@@ -1,8 +1,8 @@
 /*
-* This source file is part of an OSTIS project. For the latest info, see http://ostis.net
-* Distributed under the MIT License
-* (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
-*/
+ * This source file is part of an OSTIS project. For the latest info, see http://ostis.net
+ * Distributed under the MIT License
+ * (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
+ */
 
 #include <gtest/gtest.h>
 
@@ -16,28 +16,15 @@ TEST(scs_level_4, simple_1)
   EXPECT_TRUE(parser.Parse(data));
 
   TripleTester tester(parser);
-  tester({
-           {
-             { ScType::ConstNode, "a" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstNode, "c" }
-           },
-           {
-             { ScType::ConstNode, "b" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local }
-           },
-           {
-             { ScType::ConstNode, "a" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstNode, "d" }
-           },
-           {
-             { ScType::ConstNode, "b" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local }
-           }
-         });
+  tester(
+      {{{ScType::ConstNode, "a"}, {ScType::ConstPermPosArc, scs::Visibility::Local}, {ScType::ConstNode, "c"}},
+       {{ScType::ConstNode, "b"},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local}},
+       {{ScType::ConstNode, "a"}, {ScType::ConstPermPosArc, scs::Visibility::Local}, {ScType::ConstNode, "d"}},
+       {{ScType::ConstNode, "b"},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local}}});
 
   auto const & triples = parser.GetParsedTriples();
 
@@ -55,33 +42,24 @@ TEST(scs_level_4, simple_2)
   EXPECT_TRUE(parser.Parse(data));
 
   TripleTester tester(parser);
-  tester({
-           {
-             { ScType::ConstNode, "a" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstNode, "c" }
-           },
-           {
-             { ScType::ConstNode, "b" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-           },
-           {
-             { ScType::ConstNode, "f" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstNode, "a" }
-           },
-           {
-             { ScType::ConstNode, "d" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-           },
-           {
-             { ScType::ConstNode, "e" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-           }
-         });
+  tester(
+      {{{ScType::ConstNode, "a"}, {ScType::ConstPermPosArc, scs::Visibility::Local}, {ScType::ConstNode, "c"}},
+       {
+           {ScType::ConstNode, "b"},
+           {ScType::ConstPermPosArc, scs::Visibility::Local},
+           {ScType::ConstPermPosArc, scs::Visibility::Local},
+       },
+       {{ScType::ConstNode, "f"}, {ScType::ConstPermPosArc, scs::Visibility::Local}, {ScType::ConstNode, "a"}},
+       {
+           {ScType::ConstNode, "d"},
+           {ScType::ConstPermPosArc, scs::Visibility::Local},
+           {ScType::ConstPermPosArc, scs::Visibility::Local},
+       },
+       {
+           {ScType::ConstNode, "e"},
+           {ScType::ConstPermPosArc, scs::Visibility::Local},
+           {ScType::ConstPermPosArc, scs::Visibility::Local},
+       }});
 
   auto const & triples = parser.GetParsedTriples();
 
@@ -102,35 +80,27 @@ TEST(scs_level_4, vector_simple_1)
   TripleTester tester(parser);
   tester({
       {
-          { ScType::ConstNodeTuple, scs::Visibility::Local },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::VarNode, "_el1" },
+          {ScType::ConstNodeTuple, scs::Visibility::Local},
+          {ScType::ConstPermPosArc, scs::Visibility::Local},
+          {ScType::VarNode, "_el1"},
       },
+      {{ScType::ConstNode, "rrel_1"},
+       {ScType::ConstPermPosArc, scs::Visibility::Local},
+       {ScType::ConstPermPosArc, scs::Visibility::Local}},
       {
-          { ScType::ConstNode, "rrel_1" },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstPermPosArc, scs::Visibility::Local }
+          {ScType::ConstNodeTuple, scs::Visibility::Local},
+          {ScType::ConstPermPosArc, scs::Visibility::Local},
+          {ScType::ConstNode, "el2"},
       },
-      {
-          { ScType::ConstNodeTuple, scs::Visibility::Local },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstNode, "el2" },
-      },
-      {
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstCommonArc, scs::Visibility::Local },
-          { ScType::ConstPermPosArc, scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstNode, "nrel_basic_sequence" },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstCommonArc, scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstNode, "set1" },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstNodeTuple, scs::Visibility::Local }
-      },
+      {{ScType::ConstPermPosArc, scs::Visibility::Local},
+       {ScType::ConstCommonArc, scs::Visibility::Local},
+       {ScType::ConstPermPosArc, scs::Visibility::Local}},
+      {{ScType::ConstNode, "nrel_basic_sequence"},
+       {ScType::ConstPermPosArc, scs::Visibility::Local},
+       {ScType::ConstCommonArc, scs::Visibility::Local}},
+      {{ScType::ConstNode, "set1"},
+       {ScType::ConstPermPosArc, scs::Visibility::Local},
+       {ScType::ConstNodeTuple, scs::Visibility::Local}},
   });
 
   auto const & triples = parser.GetParsedTriples();
@@ -154,20 +124,16 @@ TEST(scs_level_4, vector_simple_2)
   TripleTester tester(parser);
   tester({
       {
-          { ScType::ConstNodeTuple, scs::Visibility::Local },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::VarNode, "_el1" },
+          {ScType::ConstNodeTuple, scs::Visibility::Local},
+          {ScType::ConstPermPosArc, scs::Visibility::Local},
+          {ScType::VarNode, "_el1"},
       },
-      {
-          { ScType::ConstNode, "rrel_1" },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstPermPosArc, scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstNode, "set1" },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstNodeTuple, scs::Visibility::Local }
-      },
+      {{ScType::ConstNode, "rrel_1"},
+       {ScType::ConstPermPosArc, scs::Visibility::Local},
+       {ScType::ConstPermPosArc, scs::Visibility::Local}},
+      {{ScType::ConstNode, "set1"},
+       {ScType::ConstPermPosArc, scs::Visibility::Local},
+       {ScType::ConstNodeTuple, scs::Visibility::Local}},
   });
 
   auto const & triples = parser.GetParsedTriples();
@@ -196,60 +162,44 @@ TEST(scs_level_4, vector_4)
   TripleTester tester(parser);
   tester({
       {
-          { ScType::ConstNodeTuple, scs::Visibility::Local },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::VarNode, "_el1" },
+          {ScType::ConstNodeTuple, scs::Visibility::Local},
+          {ScType::ConstPermPosArc, scs::Visibility::Local},
+          {ScType::VarNode, "_el1"},
       },
+      {{ScType::ConstNode, "rrel_1"},
+       {ScType::ConstPermPosArc, scs::Visibility::Local},
+       {ScType::ConstPermPosArc, scs::Visibility::Local}},
       {
-          { ScType::ConstNode, "rrel_1" },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstPermPosArc, scs::Visibility::Local }
+          {ScType::ConstNodeTuple, scs::Visibility::Local},
+          {ScType::ConstPermPosArc, scs::Visibility::Local},
+          {ScType::ConstNode, "el3"},
       },
+      {{ScType::ConstPermPosArc, scs::Visibility::Local},
+       {ScType::ConstCommonArc, scs::Visibility::Local},
+       {ScType::ConstPermPosArc, scs::Visibility::Local}},
+      {{ScType::ConstNode, "nrel_basic_sequence"},
+       {ScType::ConstPermPosArc, scs::Visibility::Local},
+       {ScType::ConstCommonArc, scs::Visibility::Local}},
+      {{ScType::ConstNodeTuple, scs::Visibility::Local},
+       {ScType::ConstPermPosArc, scs::Visibility::Local},
+       {ScType::ConstNodeTuple, scs::Visibility::Local}},
+      {{ScType::ConstNode, "rrel_1"},
+       {ScType::ConstPermPosArc, scs::Visibility::Local},
+       {ScType::ConstPermPosArc, scs::Visibility::Local}},
       {
-          { ScType::ConstNodeTuple, scs::Visibility::Local },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstNode, "el3" },
+          {ScType::ConstNodeTuple, scs::Visibility::Local},
+          {ScType::ConstPermPosArc, scs::Visibility::Local},
+          {ScType::ConstNode, "el2"},
       },
-      {
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstCommonArc, scs::Visibility::Local },
-          { ScType::ConstPermPosArc, scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstNode, "nrel_basic_sequence" },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstCommonArc, scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstNodeTuple, scs::Visibility::Local },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstNodeTuple, scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstNode, "rrel_1" },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstPermPosArc, scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstNodeTuple, scs::Visibility::Local },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstNode, "el2" },
-      },
-      {
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstCommonArc, scs::Visibility::Local },
-          { ScType::ConstPermPosArc, scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstNode, "nrel_basic_sequence" },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstCommonArc, scs::Visibility::Local }
-      },
-      {
-          { ScType::ConstNode, "set1" },
-          { ScType::ConstPermPosArc, scs::Visibility::Local },
-          { ScType::ConstNodeTuple, scs::Visibility::Local }
-      },
+      {{ScType::ConstPermPosArc, scs::Visibility::Local},
+       {ScType::ConstCommonArc, scs::Visibility::Local},
+       {ScType::ConstPermPosArc, scs::Visibility::Local}},
+      {{ScType::ConstNode, "nrel_basic_sequence"},
+       {ScType::ConstPermPosArc, scs::Visibility::Local},
+       {ScType::ConstCommonArc, scs::Visibility::Local}},
+      {{ScType::ConstNode, "set1"},
+       {ScType::ConstPermPosArc, scs::Visibility::Local},
+       {ScType::ConstNodeTuple, scs::Visibility::Local}},
   });
 
   auto const & triples = parser.GetParsedTriples();

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_level_5.cpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_level_5.cpp
@@ -1,8 +1,8 @@
 /*
-* This source file is part of an OSTIS project. For the latest info, see http://ostis.net
-* Distributed under the MIT License
-* (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
-*/
+ * This source file is part of an OSTIS project. For the latest info, see http://ostis.net
+ * Distributed under the MIT License
+ * (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
+ */
 
 #include <gtest/gtest.h>
 
@@ -17,28 +17,15 @@ TEST(scs_level_5, simple)
   EXPECT_TRUE(parser.Parse(data));
 
   TripleTester tester(parser);
-  tester({
-           {
-             { ScType::ConstNode, "item" },
-             { ScType::ConstFuzArc, scs::Visibility::Local },
-             { ScType::ConstNode, "subitem" }
-           },
-           {
-             { ScType::ConstNode, "subitem2" },
-             { ScType::ConstCommonArc, scs::Visibility::Local },
-             { ScType::ConstNode, "item" }
-           },
-           {
-             { ScType::ConstNode, "set" },
-             { ScType::ConstActualTempPosArc, scs::Visibility::Local },
-             { ScType::ConstNode, "item" }
-           },
-           {
-             { ScType::ConstNode, "attr" },
-             { ScType::VarPermPosArc, scs::Visibility::Local },
-             { ScType::ConstActualTempPosArc, scs::Visibility::Local }
-           }
-         });
+  tester(
+      {{{ScType::ConstNode, "item"}, {ScType::ConstFuzArc, scs::Visibility::Local}, {ScType::ConstNode, "subitem"}},
+       {{ScType::ConstNode, "subitem2"}, {ScType::ConstCommonArc, scs::Visibility::Local}, {ScType::ConstNode, "item"}},
+       {{ScType::ConstNode, "set"},
+        {ScType::ConstActualTempPosArc, scs::Visibility::Local},
+        {ScType::ConstNode, "item"}},
+       {{ScType::ConstNode, "attr"},
+        {ScType::VarPermPosArc, scs::Visibility::Local},
+        {ScType::ConstActualTempPosArc, scs::Visibility::Local}}});
 
   auto const & triples = parser.GetParsedTriples();
   EXPECT_EQ(triples.size(), 4u);

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_level_6.cpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_level_6.cpp
@@ -1,8 +1,8 @@
 /*
-* This source file is part of an OSTIS project. For the latest info, see http://ostis.net
-* Distributed under the MIT License
-* (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
-*/
+ * This source file is part of an OSTIS project. For the latest info, see http://ostis.net
+ * Distributed under the MIT License
+ * (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
+ */
 
 #include <gtest/gtest.h>
 
@@ -17,51 +17,37 @@ TEST(scs_level_6, set)
   EXPECT_TRUE(parser.Parse(data));
 
   TripleTester tester(parser);
-  tester({
-           {
-             { ScType::ConstNodeTuple, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstNode, "a" }
-           },
-           {
-             { ScType::ConstNodeTuple, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstNode, "c" }
-           },
-           {
-             { ScType::ConstNode, "b" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local }
-           },
-           {
-             { ScType::ConstNodeTuple, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstNode, "f" }
-           },
-           {
-             { ScType::ConstNode, "d" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local }
-           },
-           {
-             { ScType::ConstNode, "e" },
-             { ScType::ConstPermPosArc, scs::Visibility::Local },
-             { ScType::ConstPermPosArc, scs::Visibility::Local }
-           }
-         });
+  tester(
+      {{{ScType::ConstNodeTuple, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstNode, "a"}},
+       {{ScType::ConstNodeTuple, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstNode, "c"}},
+       {{ScType::ConstNode, "b"},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local}},
+       {{ScType::ConstNodeTuple, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstNode, "f"}},
+       {{ScType::ConstNode, "d"},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local}},
+       {{ScType::ConstNode, "e"},
+        {ScType::ConstPermPosArc, scs::Visibility::Local},
+        {ScType::ConstPermPosArc, scs::Visibility::Local}}});
 }
 
 TEST(scs_level_6, smoke)
 {
   std::vector<std::string> data = {
-    "z -> [**];;",
-    "x -> [test*];;",
-    "@a = [\\[* r-> b;; *\\]];;",
-    "@alias = u;; @alias -> [* x -> [* y -> z;; *];; *];;",
-    "y <= nrel_main_idtf: [y*];;",
-    "a -> [* z -> [begin*];; *];;",
-    "a -> [* b -> c;; *];;"
-  };
+      "z -> [**];;",
+      "x -> [test*];;",
+      "@a = [\\[* r-> b;; *\\]];;",
+      "@alias = u;; @alias -> [* x -> [* y -> z;; *];; *];;",
+      "y <= nrel_main_idtf: [y*];;",
+      "a -> [* z -> [begin*];; *];;",
+      "a -> [* b -> c;; *];;"};
 
   for (auto const & d : data)
   {
@@ -187,7 +173,6 @@ TEST(scs_level_6, contour_empty)
   EXPECT_EQ(trg.GetType(), ScType::ConstNodeStructure);
 }
 
-
 TEST(scs_level_6, contour_parse_error)
 {
   {
@@ -206,7 +191,6 @@ TEST(scs_level_6, contour_parse_error)
     EXPECT_FALSE(parser.Parse(data));
   }
 }
-
 
 TEST(scs_level_6, contour_simple)
 {
@@ -295,7 +279,6 @@ TEST(scs_level_6, contour_recursive)
     EXPECT_EQ(trg.GetType(), ScType::ConstNodeStructure);
   }
 }
-
 
 TEST(scs_level_6, contout_with_content)
 {

--- a/sc-memory/sc-memory/tests/scs/units/test_scs_utils.hpp
+++ b/sc-memory/sc-memory/tests/scs/units/test_scs_utils.hpp
@@ -11,29 +11,38 @@
 #include "sc-memory/scs/scs_parser.hpp"
 
 #define SPLIT_TRIPLE(t) \
-  auto const & src = parser.GetParsedElement(t.m_source); SC_UNUSED(src); \
-  auto const & connector = parser.GetParsedElement(t.m_connector); SC_UNUSED(connector); \
-  auto const & trg = parser.GetParsedElement(t.m_target); SC_UNUSED(trg)
+  auto const & src = parser.GetParsedElement(t.m_source); \
+  SC_UNUSED(src); \
+  auto const & connector = parser.GetParsedElement(t.m_connector); \
+  SC_UNUSED(connector); \
+  auto const & trg = parser.GetParsedElement(t.m_target); \
+  SC_UNUSED(trg)
 
 struct TripleElement
 {
   TripleElement(ScType const & type)
-        : m_type(type), m_visibility(scs::Visibility::System)
+    : m_type(type)
+    , m_visibility(scs::Visibility::System)
   {
   }
 
   TripleElement(ScType const & type, std::string const & idtf)
-        : m_type(type), m_idtf(idtf), m_visibility(scs::Visibility::System)
+    : m_type(type)
+    , m_idtf(idtf)
+    , m_visibility(scs::Visibility::System)
   {
   }
 
   TripleElement(ScType const & type, std::string const & idtf, scs::Visibility const & vis)
-        : m_type(type), m_idtf(idtf), m_visibility(vis)
+    : m_type(type)
+    , m_idtf(idtf)
+    , m_visibility(vis)
   {
   }
 
   TripleElement(ScType const & type, scs::Visibility const & vis)
-        : m_type(type), m_visibility(vis)
+    : m_type(type)
+    , m_visibility(vis)
   {
   }
 
@@ -56,11 +65,9 @@ struct TripleElement
 inline std::ostream & operator<<(std::ostream & out, TripleElement const & t)
 {
   SC_LOG_ERROR(
-        "{ m_type: " << *t.m_type << ", m_idtf: \""
-                     << t.m_idtf << "\", m_visibility: " << int(t.m_visibility) << " }");
+      "{ m_type: " << *t.m_type << ", m_idtf: \"" << t.m_idtf << "\", m_visibility: " << int(t.m_visibility) << " }");
   return out;
 }
-
 
 struct TripleResult
 {
@@ -79,10 +86,10 @@ struct TripleResult
     catch (utils::ScException const & ex)
     {
       SC_LOG_ERROR(
-            "\nShould be: " << std::endl
-                            << " m_source: " << m_source << ", " << std::endl
-                            << " m_connector: " << m_connector << ", " << std::endl
-                            << " m_target: " << m_target << std::endl);
+          "\nShould be: " << std::endl
+                          << " m_source: " << m_source << ", " << std::endl
+                          << " m_connector: " << m_connector << ", " << std::endl
+                          << " m_target: " << m_target << std::endl);
 
       auto const elToString = [](scs::ParsedElement const & el) -> std::string
       {
@@ -94,10 +101,10 @@ struct TripleResult
       };
 
       SC_LOG_ERROR(
-            "\nParsed: " << std::endl
-                         << " m_source: " << elToString(src) << std::endl
-                         << " m_connector: " << elToString(connector) << std::endl
-                         << " m_target: " << elToString(trg) << std::endl);
+          "\nParsed: " << std::endl
+                       << " m_source: " << elToString(src) << std::endl
+                       << " m_connector: " << elToString(connector) << std::endl
+                       << " m_target: " << elToString(trg) << std::endl);
 
       throw ex;
     }
@@ -108,13 +115,14 @@ struct TripleResult
   TripleElement m_target;
 };
 
-
 using ResultTriples = std::vector<TripleResult>;
 
 struct TripleTester
 {
-  explicit TripleTester(scs::Parser const & parser) : m_parser(parser)
-  {}
+  explicit TripleTester(scs::Parser const & parser)
+    : m_parser(parser)
+  {
+  }
 
   void operator()(ResultTriples const & resultTriples)
   {

--- a/sc-tools/sc-builder/include/sc-builder/scs_loader.hpp
+++ b/sc-tools/sc-builder/include/sc-builder/scs_loader.hpp
@@ -11,5 +11,5 @@
 class ScsLoader
 {
 public:
-  bool loadScsFile(ScMemoryContext & context, const std::string & filename);
+  bool loadScsFile(ScMemoryContext & context, std::string const & filename);
 };

--- a/sc-tools/sc-builder/src/scs_loader.cpp
+++ b/sc-tools/sc-builder/src/scs_loader.cpp
@@ -10,7 +10,7 @@
 
 #include "scs_translator.hpp"
 
-bool ScsLoader::loadScsFile(ScMemoryContext &context, const std::string &filename)
+bool ScsLoader::loadScsFile(ScMemoryContext & context, std::string const & filename)
 {
   SCsTranslator translator = SCsTranslator(context);
 

--- a/sc-tools/sc-builder/src/scs_translator.cpp
+++ b/sc-tools/sc-builder/src/scs_translator.cpp
@@ -61,7 +61,7 @@ private:
   std::string m_parentPath;
 };
 
-} // namespace impl
+}  // namespace impl
 
 SCsTranslator::SCsTranslator(ScMemoryContext & context)
   : Translator(context)


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/CONTRIBUTING.md)
* [x] Update changelog
* [x] Update documentation

Now, sc-arcs between sc-element types and sc-elements are not generated in sc-memory. This allows for:
- fixing cases where these sc-arcs belong to sc-structures (in particular, sc-templates) and hinder the processing of these sc-templates (searching by sc-template);
- improving visualization of the semantic neighborhoods of certain types of sc-elements.
