### PR TITLE
[tools][builder] Ignore extensions_path in config; mark repo_path as path

### DIFF
--- a/sc-tools/sc-builder/src/sc_builder_runner.cpp
+++ b/sc-tools/sc-builder/src/sc_builder_runner.cpp
@@ -80,7 +80,10 @@ try
   if (!params.m_outputPath.empty())
     memoryParams.Insert({"storage", params.m_outputPath});
 
-  ScConfig config{configPath, {"storage", "log_file", "input_path", "input", "output"}, {"extensions"}};
+  ScConfig config{
+      configPath,
+      {"repo_path", "storage", "log_file", "input_path", "input", "output"},
+      {"extensions", "extensions_path"}};
   ScMemoryConfig memoryConfig{config, memoryParams};
   sc_memory_params formedMemoryParams = memoryConfig.GetParams();
 


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/CONTRIBUTING.md)
* [ ] Update changelog
* [ ] Update documentation

Fixes launching sc-builder without extensions if config uses deprecated `extensions_path` option.
