### PR TITLE
[memory][actions][tests] Don't generate action result if there is already another one

### DIFF
--- a/docs/sc-memory/api/cpp/extended/agents/actions.md
+++ b/docs/sc-memory/api/cpp/extended/agents/actions.md
@@ -327,6 +327,9 @@ ScResult const & result = action.FinishSuccessfully();
 <scg src="../images/actions/action_finished_successfully.gwf"></scg>
 
 !!! warning
+    If you finish action successfully that already has result, then this method will throw `utils::ExceptionInvalidState`.
+
+!!! warning
     If you finish action successfully that is finished or not initiated, then this method will throw `utils::ExceptionInvalidState`.
 
 #### **IsFinishedUnsuccessfully**
@@ -358,6 +361,9 @@ ScResult const & result = action.FinishUnsuccessfully();
 <scg src="../images/actions/action_finished_unsuccessfully.gwf"></scg>
 
 !!! warning
+    If you finish action unsuccessfully that already has result, then this method will throw `utils::ExceptionInvalidState`.
+
+!!! warning
     If you finish action unsuccessfully that is finished or not initiated, then this method will throw `utils::ExceptionInvalidState`.
 
 #### **IsFinishedWithError**
@@ -384,6 +390,9 @@ ScResult const & result = action.FinishWithError();
 ```
 
 <scg src="../images/actions/action_finished_with_error.gwf"></scg>
+
+!!! warning
+    If you finish action with error that already has result, then this method will throw `utils::ExceptionInvalidState`.
 
 !!! warning
     If you finish action with error that is finished or not initiated, then this method will throw `utils::ExceptionInvalidState`.

--- a/sc-memory/sc-memory/include/sc-memory/sc_action.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/sc_action.hpp
@@ -172,6 +172,7 @@ public:
    * @brief Marks the action as finished successfully.
    * @return Result of the operation.
    * @throws utils::ExceptionInvalidState if the action is not initiated or already finished.
+   * @throws utils::ExceptionInvalidState if the action already has result.
    */
   _SC_EXTERN ScResult FinishSuccessfully() noexcept(false);
 
@@ -185,6 +186,7 @@ public:
    * @brief Marks the action as finished unsuccessfully.
    * @return Result of the operation.
    * @throws utils::ExceptionInvalidState if the action is not initiated or already finished.
+   * @throws utils::ExceptionInvalidState if the action already has result.
    */
   _SC_EXTERN ScResult FinishUnsuccessfully() noexcept(false);
 
@@ -198,6 +200,7 @@ public:
    * @brief Marks the action as finished with an error.
    * @return Result of the operation.
    * @throws utils::ExceptionInvalidState if the action is not initiated or already finished.
+   * @throws utils::ExceptionInvalidState if the action already has result.
    */
   _SC_EXTERN ScResult FinishWithError() noexcept(false);
 

--- a/sc-memory/sc-memory/include/sc-memory/sc_result.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/sc_result.hpp
@@ -19,7 +19,7 @@ class ScResult : public ScObject
   friend class ScAgent;
   friend class ScAction;
 
-private:
+protected:
   sc_result m_code;
 
   _SC_EXTERN ScResult();

--- a/sc-memory/sc-memory/src/sc_action.cpp
+++ b/sc-memory/sc-memory/src/sc_action.cpp
@@ -214,11 +214,27 @@ void ScAction::Finish(ScAddr const & actionStateAddr) noexcept(false)
         "Not able to finish action " << GetActionPrettyString() << GetActionClassPrettyString()
                                      << " because it had already been finished.");
 
-  if (!m_context->IsElement(m_resultAddr))
-    m_resultAddr = m_context->GenerateNode(ScType::ConstNodeStructure);
+  ScIterator5Ptr const resultIt = m_context->CreateIterator5(
+      *this, ScType::ConstCommonArc, ScType::ConstNode, ScType::ConstPermPosArc, ScKeynodes::nrel_result);
+  if (resultIt->Next())
+  {
+    ScAddr const & findResultAddr = resultIt->Get(2);
+    if (m_context->IsElement(m_resultAddr) && findResultAddr != m_resultAddr)
+    {
+      m_context->EraseElement(findResultAddr);
 
-  ScAddr const & arcAddr = m_context->GenerateConnector(ScType::ConstCommonArc, *this, m_resultAddr);
-  m_context->GenerateConnector(ScType::ConstPermPosArc, ScKeynodes::nrel_result, arcAddr);
+      ScAddr const & arcAddr = m_context->GenerateConnector(ScType::ConstCommonArc, *this, m_resultAddr);
+      m_context->GenerateConnector(ScType::ConstPermPosArc, ScKeynodes::nrel_result, arcAddr);
+    }
+  }
+  else
+  {
+    if (!m_context->IsElement(m_resultAddr))
+      m_resultAddr = m_context->GenerateNode(ScType::ConstNodeStructure);
+
+    ScAddr const & arcAddr = m_context->GenerateConnector(ScType::ConstCommonArc, *this, m_resultAddr);
+    m_context->GenerateConnector(ScType::ConstPermPosArc, ScKeynodes::nrel_result, arcAddr);
+  }
 
   m_context->GenerateConnector(ScType::ConstPermPosArc, actionStateAddr, *this);
   m_context->GenerateConnector(ScType::ConstPermPosArc, ScKeynodes::action_finished, *this);

--- a/sc-memory/sc-memory/src/sc_action.cpp
+++ b/sc-memory/sc-memory/src/sc_action.cpp
@@ -215,17 +215,16 @@ void ScAction::Finish(ScAddr const & actionStateAddr) noexcept(false)
                                      << " because it had already been finished.");
 
   ScIterator5Ptr const resultIt = m_context->CreateIterator5(
-      *this, ScType::ConstCommonArc, ScType::ConstNode, ScType::ConstPermPosArc, ScKeynodes::nrel_result);
+      *this, ScType::ConstCommonArc, ScType::Unknown, ScType::ConstPermPosArc, ScKeynodes::nrel_result);
   if (resultIt->Next())
   {
-    ScAddr const & findResultAddr = resultIt->Get(2);
-    if (m_context->IsElement(m_resultAddr) && findResultAddr != m_resultAddr)
-    {
-      m_context->EraseElement(findResultAddr);
-
-      ScAddr const & arcAddr = m_context->GenerateConnector(ScType::ConstCommonArc, *this, m_resultAddr);
-      m_context->GenerateConnector(ScType::ConstPermPosArc, ScKeynodes::nrel_result, arcAddr);
-    }
+    ScAddr const & foundResultAddr = resultIt->Get(2);
+    if (m_context->IsElement(m_resultAddr) && foundResultAddr != m_resultAddr)
+      SC_THROW_EXCEPTION(
+          utils::ExceptionInvalidState,
+          "Not able to set result `" << m_resultAddr.Hash() << "` for action " << GetActionPrettyString()
+                                     << GetActionClassPrettyString() << " because it already has result `"
+                                     << foundResultAddr.Hash() << "`.");
   }
   else
   {

--- a/sc-memory/sc-memory/tests/sc-memory/units/agents/test_sc_action.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/agents/test_sc_action.cpp
@@ -182,6 +182,35 @@ TEST_F(ScActionTest, GenerateActionAndSetGetResult)
   EXPECT_EQ(result, structureAddr2);
 }
 
+TEST_F(ScActionTest, GenerateActionAndSetGetArcAsResult)
+{
+  ScAddr const & testClassAddr = m_ctx->GenerateNode(ScType::ConstNodeClass);
+  ScAction action = m_ctx->GenerateAction(testClassAddr);
+
+  EXPECT_THROW(action.GetResult(), utils::ExceptionInvalidState);
+  EXPECT_FALSE(action.InitiateAndWait(1));
+
+  EXPECT_THROW(action.GetResult(), utils::ExceptionInvalidState);
+  ScAddr const & nodeAddr1 = m_ctx->GenerateNode(ScType::ConstNodeStructure);
+  ScAddr const & arcAddr1 = m_ctx->GenerateConnector(ScType::ConstPermPosArc, nodeAddr1, nodeAddr1);
+  EXPECT_NO_THROW(action.SetResult(arcAddr1));
+  EXPECT_NO_THROW(action.SetResult(arcAddr1));
+
+  ScAddr const & nodeAddr2 = m_ctx->GenerateNode(ScType::ConstNodeStructure);
+  ScAddr const & arcAddr2 = m_ctx->GenerateConnector(ScType::ConstPermPosArc, nodeAddr2, nodeAddr2);
+  EXPECT_NO_THROW(action.SetResult(arcAddr2));
+  EXPECT_FALSE(m_ctx->IsElement(arcAddr1));
+  EXPECT_THROW(action.SetResult(arcAddr1), utils::ExceptionInvalidParams);
+  EXPECT_NO_THROW(action.SetResult(arcAddr2));
+
+  action.FinishSuccessfully();
+  EXPECT_THROW(action.SetResult(arcAddr2), utils::ExceptionInvalidState);
+  ScStructure const & result = action.GetResult();
+  EXPECT_TRUE(result.IsEmpty());
+  EXPECT_EQ(result, action.GetResult());
+  EXPECT_EQ(result, arcAddr2);
+}
+
 TEST_F(ScActionTest, GenerateActionAndSetResultIfOtherResultExists)
 {
   ScAddr const & testClassAddr = m_ctx->GenerateNode(ScType::ConstNodeClass);
@@ -199,8 +228,7 @@ TEST_F(ScActionTest, GenerateActionAndSetResultIfOtherResultExists)
   ScAddr const & structureAddr2 = m_ctx->GenerateNode(ScType::ConstNodeStructure);
   action.SetResult(structureAddr2);
 
-  action.FinishSuccessfully();
-  EXPECT_EQ(action.GetResult(), structureAddr2);
+  EXPECT_THROW(action.FinishSuccessfully(), utils::ExceptionInvalidState);
 }
 
 TEST_F(ScActionTest, GenerateActionAndDontSetResultIfOtherResultExists)

--- a/sc-memory/sc-memory/tests/sc-memory/units/agents/test_sc_action.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/agents/test_sc_action.cpp
@@ -231,6 +231,25 @@ TEST_F(ScActionTest, GenerateActionAndSetResultIfOtherResultExists)
   EXPECT_THROW(action.FinishSuccessfully(), utils::ExceptionInvalidState);
 }
 
+TEST_F(ScActionTest, GenerateActionAndSetResultIfSameResultExists)
+{
+  ScAddr const & testClassAddr = m_ctx->GenerateNode(ScType::ConstNodeClass);
+  ScAction action = m_ctx->GenerateAction(testClassAddr);
+
+  EXPECT_THROW(action.GetResult(), utils::ExceptionInvalidState);
+  EXPECT_FALSE(action.InitiateAndWait(1));
+
+  EXPECT_THROW(action.GetResult(), utils::ExceptionInvalidState);
+
+  ScAddr const & structureAddr1 = m_ctx->GenerateNode(ScType::ConstNodeStructure);
+  ScAddr const & arcAddr = m_ctx->GenerateConnector(ScType::ConstCommonArc, action, structureAddr1);
+  m_ctx->GenerateConnector(ScType::ConstPermPosArc, ScKeynodes::nrel_result, arcAddr);
+
+  action.SetResult(structureAddr1);
+  EXPECT_NO_THROW(action.FinishSuccessfully());
+  EXPECT_EQ(action.GetResult(), structureAddr1);
+}
+
 TEST_F(ScActionTest, GenerateActionAndDontSetResultIfOtherResultExists)
 {
   ScAddr const & testClassAddr = m_ctx->GenerateNode(ScType::ConstNodeClass);

--- a/sc-memory/sc-memory/tests/sc-memory/units/agents/test_sc_action.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/agents/test_sc_action.cpp
@@ -182,6 +182,45 @@ TEST_F(ScActionTest, GenerateActionAndSetGetResult)
   EXPECT_EQ(result, structureAddr2);
 }
 
+TEST_F(ScActionTest, GenerateActionAndSetResultIfOtherResultExists)
+{
+  ScAddr const & testClassAddr = m_ctx->GenerateNode(ScType::ConstNodeClass);
+  ScAction action = m_ctx->GenerateAction(testClassAddr);
+
+  EXPECT_THROW(action.GetResult(), utils::ExceptionInvalidState);
+  EXPECT_FALSE(action.InitiateAndWait(1));
+
+  EXPECT_THROW(action.GetResult(), utils::ExceptionInvalidState);
+
+  ScAddr const & structureAddr1 = m_ctx->GenerateNode(ScType::ConstNodeStructure);
+  ScAddr const & arcAddr = m_ctx->GenerateConnector(ScType::ConstCommonArc, action, structureAddr1);
+  m_ctx->GenerateConnector(ScType::ConstPermPosArc, ScKeynodes::nrel_result, arcAddr);
+
+  ScAddr const & structureAddr2 = m_ctx->GenerateNode(ScType::ConstNodeStructure);
+  action.SetResult(structureAddr2);
+
+  action.FinishSuccessfully();
+  EXPECT_EQ(action.GetResult(), structureAddr2);
+}
+
+TEST_F(ScActionTest, GenerateActionAndDontSetResultIfOtherResultExists)
+{
+  ScAddr const & testClassAddr = m_ctx->GenerateNode(ScType::ConstNodeClass);
+  ScAction action = m_ctx->GenerateAction(testClassAddr);
+
+  EXPECT_THROW(action.GetResult(), utils::ExceptionInvalidState);
+  EXPECT_FALSE(action.InitiateAndWait(1));
+
+  EXPECT_THROW(action.GetResult(), utils::ExceptionInvalidState);
+
+  ScAddr const & structureAddr1 = m_ctx->GenerateNode(ScType::ConstNodeStructure);
+  ScAddr const & arcAddr = m_ctx->GenerateConnector(ScType::ConstCommonArc, action, structureAddr1);
+  m_ctx->GenerateConnector(ScType::ConstPermPosArc, ScKeynodes::nrel_result, arcAddr);
+
+  action.FinishSuccessfully();
+  EXPECT_EQ(action.GetResult(), structureAddr1);
+}
+
 TEST_F(ScActionTest, GenerateActionAndSetRemoveGetResult)
 {
   ScAddr const & testClassAddr = m_ctx->GenerateNode(ScType::ConstNodeClass);

--- a/scripts/install_deps_macOS.sh
+++ b/scripts/install_deps_macOS.sh
@@ -6,6 +6,6 @@ then
   source "$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)/set_vars.sh"
 fi
 
-brew install glib antlr antlr4-cpp-runtime temurin pkgconfig cmake ninja ccache asio websocketpp nlohmann-json libxml2
+brew install glib antlr antlr4-cpp-runtime temurin cmake ninja ccache asio websocketpp nlohmann-json libxml2
 
 "${SC_MACHINE_PATH}/scripts/install_deps_python.sh"


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/CONTRIBUTING.md)
* [ ] Update changelog
* [ ] Update documentation

Especially for scp-agents. Fixes generation of result for action, if this action already has another result. See https://github.com/ostis-ai/scp-machine/pull/32 also. 