### PR TITLE
[tools][server] Environment variables for sc-server host and port 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - "BINARY_PATH=/sc-machine/build/Release/bin"
       - "EXTENSIONS_PATH=/sc-machine/build/Release/lib/extensions"
       - "CONFIG_PATH=/sc-machine/sc-machine.ini"
+      - "SC_SERVER_HOST=0.0.0.0"
     command:
       - "run"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Using sc-machine as a library is much more optimized: adding it to the CMake tree is no longer necessary. You can install sc-machine packages and import sc-machine targets into your cmake using `find_package(sc-machine REQUIRED)`. See how to do it -- [Build System](build/build_system.md)
     - Each release sc-machine binaries are being compiled for supported OS and formed as an archives on Github. Minimum required version of macOS is macOS-14 (arm), of ubuntu is ubuntu-22.04. The sc-machine doesn't support ubuntu-20.04 anymore. You can use sc-machine binaries to work with sc-memory or you can use `RunMachine` method from `sc-machine-runner.so` to create your own entry point to initialize sc-memory instead of using compiled `sc-machine` binary.
     - Script for the project build (`build_sc_machine.sh`), scripts for running binaries (`run_sc_server.sh`, `build_kb.sh`) were removed from the sc-machine repository scripts. You should use sc-machine binaries directly.
-    - sc-server is no longer entry point of the sc-machine, it is an extension (`sc-server-lib.so`), that is loaded dynamically when the machine is started. So, `sc-server` binary was removed, `sc-machine` binary was added instead.
+    - sc-server is no longer entry point of the sc-machine, it is an extension (`sc-server-lib.so`), that is loaded dynamically when the machine is started. So, `sc-server` binary was removed, `sc-machine` binary was added instead. To specify host and port for sc-server without using config, use environment variables `SC_SERVER_HOST` and `SC_SERVER_PORT` accordingly.
 - Config was changed:
     - `repo_path` option in `[sc-memory]` group was deprecated, `storage` option was added instead;
     - `extensions_path` option in `[sc-memory]` group was deprecated, `extensions` option was added instead.
@@ -163,6 +163,7 @@ See documentation, to learn more about using new API.
 
 ### Added
 
+- Environment variables `SC_SERVER_HOST` and `SC_SERVER_PORT` for sc-server
 - `SearchLinksByContentSubstring` method with `ScLinkFilter` parameter
 - `ScLinkFilter` class to specify search criteria for sc-links
 - Intro for documentation

--- a/docs/sc-tools/sc_machine.md
+++ b/docs/sc-tools/sc_machine.md
@@ -26,6 +26,12 @@ Options:
   --test|-t                               Test sc-memory state. If this flag is specified, sc-memory will be initialized and shutdown immediately.
   --version                               Display version of ./build/<Release|Debug>/bin/sc-machine.
   --help                                  Display this help message.
+
+Environment variables:
+  SC_SERVER_HOST                          Specifies a host for sc-server extension. If not set, the value defaults to the `host` option in the `[sc-server]` group of the configuration file.
+                                          If neither is specified, the default host is 127.0.0.1.
+  SC_SERVER_PORT                          Specifies a port for sc-server extension. If not set, the value defaults to the `port` option in the `[sc-server]` group of the configuration file.
+                                          If neither is specified, the default port is 8090.
 ```
 
 Example of usage:

--- a/sc-tools/sc-machine-runner/src/sc_machine_runner.cpp
+++ b/sc-tools/sc-machine-runner/src/sc_machine_runner.cpp
@@ -50,7 +50,14 @@ void PrintHelpMessage(std::string const & binaryName)
       << "  --test|-t                               Test sc-memory state. "
       << "If this flag is specified, sc-memory will be initialized and shutdown immediately.\n"
       << "  --version                               Display version of " << binaryName << ".\n"
-      << "  --help                                  Display this help message.\n";
+      << "  --help                                  Display this help message.\n\n"
+      << "Environment variables:\n"
+      << "  SC_SERVER_HOST                          Specifies a host for sc-server extension. If not set, the value "
+         "defaults to the `host` option in the `[sc-server]` group of the configuration file.\n"
+         "                                          If neither is specified, the default host is 127.0.0.1.\n"
+      << "  SC_SERVER_PORT                          Specifies a port for sc-server extension. If not set, the value "
+         "defaults to the `port` option in the `[sc-server]` group of the configuration file.\n"
+         "                                          If neither is specified, the default port is 8090.\n";
 }
 
 sc_int RunMachine(sc_int argc, sc_char * argv[])

--- a/sc-tools/sc-server/src/sc-server-impl/sc_server.cpp
+++ b/sc-tools/sc-server/src/sc-server-impl/sc_server.cpp
@@ -21,7 +21,7 @@ ScServer::ScServer(std::string hostName, size_t port)
 
   {
     LogMessage(ScServerErrorLevel::info, "Socket data:");
-    LogMessage(ScServerErrorLevel::info, "\tHost name: " + m_hostName);
+    LogMessage(ScServerErrorLevel::info, "\tHost: " + m_hostName);
     LogMessage(ScServerErrorLevel::info, "\tPort: " + std::to_string(m_port));
   }
 

--- a/sc-tools/sc-server/src/sc-server-impl/sc_server.cpp
+++ b/sc-tools/sc-server/src/sc-server-impl/sc_server.cpp
@@ -11,7 +11,7 @@
 #include <sc-memory/sc_keynodes.hpp>
 
 ScServer::ScServer(std::string hostName, size_t port)
-  : m_hostName(std::move(hostName))
+  : m_host(std::move(hostName))
   , m_port(port)
   , m_logger(nullptr)
 {
@@ -21,7 +21,7 @@ ScServer::ScServer(std::string hostName, size_t port)
 
   {
     LogMessage(ScServerErrorLevel::info, "Socket data:");
-    LogMessage(ScServerErrorLevel::info, "\tHost: " + m_hostName);
+    LogMessage(ScServerErrorLevel::info, "\tHost: " + m_host);
     LogMessage(ScServerErrorLevel::info, "\tPort: " + std::to_string(m_port));
   }
 
@@ -38,7 +38,7 @@ void ScServer::Run()
 
   Initialize();
 
-  m_instance->listen({asio::ip::address::from_string(m_hostName), sc_uint16(m_port)});
+  m_instance->listen({asio::ip::address::from_string(m_host), sc_uint16(m_port)});
   m_instance->start_accept();
 
   LogMessage(ScServerErrorLevel::info, "Start actions processing");
@@ -108,7 +108,7 @@ void ScServer::Shutdown()
 
 std::string ScServer::GetUri()
 {
-  return "ws://" + m_hostName + ":" + std::to_string(m_port);
+  return "ws://" + m_host + ":" + std::to_string(m_port);
 }
 
 bool ScServer::IsSessionValid(ScServerSessionId const & sessionId)

--- a/sc-tools/sc-server/src/sc-server-impl/sc_server.hpp
+++ b/sc-tools/sc-server/src/sc-server-impl/sc_server.hpp
@@ -61,7 +61,7 @@ public:
 
 protected:
   std::atomic<sc_bool> m_isServerRun = SC_FALSE;
-  std::string m_hostName;
+  std::string m_host;
   ScServerPort m_port;
 
   ScServerLogger * m_logger;

--- a/sc-tools/sc-server/src/sc_server_module.cpp
+++ b/sc-tools/sc-server/src/sc_server_module.cpp
@@ -6,6 +6,8 @@
 
 #include "sc_server_module.hpp"
 
+#include <cstdlib>
+
 #include "sc_server_setup.hpp"
 
 SC_MODULE_REGISTER(ScServerModule);
@@ -15,8 +17,16 @@ ScParams ScServerModule::ms_serverParams;
 
 void ScServerModule::Initialize(ScMemoryContext *)
 {
-  // It is backward compatible logic. When all platform-dependent components will be configured from kb it will be
-  // removed.
+  // TODO(NikitaZotov): Configure all platform-dependent components from kb.
+
+  sc_char const * host = std::getenv("SC_SERVER_HOST");
+  if (host != null_ptr)
+    ms_serverParams.Insert({"host", host});
+
+  sc_char const * port = std::getenv("SC_SERVER_PORT");
+  if (port != null_ptr)
+    ms_serverParams.Insert({"port", port});
+
   ScConfig config{ScMemory::ms_configPath, {{"log_file"}}};
   ScConfigGroup serverConfig = config["sc-server"];
   for (auto const & key : *serverConfig)

--- a/sc-tools/sc-server/src/sc_server_module.cpp
+++ b/sc-tools/sc-server/src/sc_server_module.cpp
@@ -20,11 +20,11 @@ void ScServerModule::Initialize(ScMemoryContext *)
   // TODO(NikitaZotov): Configure all platform-dependent components from kb.
 
   sc_char const * host = std::getenv("SC_SERVER_HOST");
-  if (host != null_ptr)
+  if (host != nullptr)
     ms_serverParams.Insert({"host", host});
 
   sc_char const * port = std::getenv("SC_SERVER_PORT");
-  if (port != null_ptr)
+  if (port != nullptr)
     ms_serverParams.Insert({"port", port});
 
   ScConfig config{ScMemory::ms_configPath, {{"log_file"}}};

--- a/sc-tools/sc-server/tests/units/api/test_connection.cpp
+++ b/sc-tools/sc-server/tests/units/api/test_connection.cpp
@@ -6,6 +6,8 @@
 
 #include "sc_server_test.hpp"
 
+#include <cstdlib>
+
 #include <sc-config/sc_options.hpp>
 #include <sc-config/sc_config.hpp>
 #include <sc-config/sc_memory_config.hpp>
@@ -52,6 +54,21 @@ TEST_F(ScServerModuleTest, RunStopServerModule)
 
   ScServerModule serverModule;
   serverModule.Initialize(m_ctx.get());
+  serverModule.Shutdown(m_ctx.get());
+}
+
+TEST_F(ScServerModuleTest, RunStopServerModuleWithHostAndPortFromEnvs)
+{
+  ScMemory::ms_configPath = ScServerTest::SC_SERVER_INI;
+
+  setenv("SC_SERVER_HOST", "0.0.0.0", true);
+  setenv("SC_SERVER_PORT", "8099", true);
+
+  ScServerModule serverModule;
+  serverModule.Initialize(m_ctx.get());
+
+  EXPECT_EQ(ScServerModule::m_server->GetUri(), "ws://0.0.0.0:8099");
+
   serverModule.Shutdown(m_ctx.get());
 }
 


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/CONTRIBUTING.md)
* [x] Update changelog
* [x] Update documentation

Now there is no problem to specify host and port for sc-server in docker-compose.yml in projects.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add environment variables `SC_SERVER_HOST` and `SC_SERVER_PORT` for sc-server configuration, with updates to documentation and source code.
> 
>   - **Environment Variables**:
>     - Introduce `SC_SERVER_HOST` and `SC_SERVER_PORT` for sc-server configuration in `docker-compose.yml` and `sc_server_module.cpp`.
>     - Default values are 127.0.0.1 for host and 8090 for port if not set.
>   - **Documentation**:
>     - Update `changelog.md` and `sc_machine.md` to include new environment variables.
>   - **Code Changes**:
>     - Modify `sc_server_module.cpp` to read host and port from environment variables.
>     - Update log message in `sc_server.cpp` to reflect "Host" instead of "Host name".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for 768edc824c49d4c027ed81bad01fc7648c9e4be9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->