### PR TITLE
[docs] Add installing pipx and conan into quick start for users

### DIFF
--- a/docs/build/build_system.md
+++ b/docs/build/build_system.md
@@ -9,10 +9,10 @@ The project uses CMake as the build system generator. CMake allows for cross-pla
 ## Compilation steps
 
 !!! warning
-    Our build system settings require using CMake 3.24 or newer. Make sure your version is compatible by running `cmake --version` and use the [CMake installation guide](https://cliutils.gitlab.io/modern-cmake/chapters/intro/installing.html) to upgrade to latest version if yours is older than 3.24. The universal method is to use `pipx install cmake` (don't forget to run `pipx ensurepath` and relaunching your shell after installation), but you may choose reconfiguring your OS's package manager instead.
+    Our build system settings require using CMake 3.24 or newer. Make sure your version is compatible by running `cmake --version` and use the [CMake installation guide](https://cliutils.gitlab.io/modern-cmake/chapters/intro/installing.html) to upgrade to latest version if yours is older than 3.24. The universal method is to use `pipx install cmake` (don't forget to run `pipx ensurepath` and relaunching your shell after installation `exec $SHELL`), but you may choose reconfiguring your OS's package manager instead.
 
 !!! warning
-    By default, our build system use the Ninja generator for building (see CMakePresets.json). Ensure that Ninja is installed and properly configured in your environment. To upgrade it, use `pipx install ninja`. Don't forget to run `pipx ensurepath` and relaunching your shell after installation.
+    By default, our build system use the Ninja generator for building (see CMakePresets.json). Ensure that Ninja is installed and properly configured in your environment. To upgrade it, use `pipx install ninja`. Don't forget to run `pipx ensurepath` and relaunching your shell after installation `exec $SHELL`.
 
 Typical configurations of the project are provided in the `CMakePresets.json` file – this means that if you use a modern IDE, **no additional configuration is needed**. Just pick one of the configurations provided by this file and use controls in your IDE to recompile and run tests (should work with VSCode + CMake Tools extension, JetBrains CLion and probably many others).
 

--- a/docs/build/quick_start.md
+++ b/docs/build/quick_start.md
@@ -4,17 +4,18 @@ This guide provides short information for developers to start to work with sc-ma
 
 ## Check CMake
 
+Install pipx first using [**pipx installation guide**](https://pipx.pypa.io/stable/installation/) if not already installed.
+
 Ensure you are using **CMake version 3.24** or newer. Verify your version with:
 
 ```sh
 cmake --version
 ```
 
-To upgrade CMake, follow the installation guide appropriate for your OS or use:
+To upgrade CMake, run:
   
 ```sh
 # Use pipx to install cmake if not already installed
-# Install pipx first using guide: https://pipx.pypa.io/stable/installation/
 pipx install cmake
 pipx ensurepath
 # relaunch your shell after installation

--- a/docs/build/quick_start.md
+++ b/docs/build/quick_start.md
@@ -33,7 +33,7 @@ pipx ensurepath
 
 ### Install Conan
 
-Install Conan, to build sc-machine dependencies with Conan-provided dependencies:
+Install Conan, to build sc-machine with Conan-provided dependencies:
 
 ```sh
 # Use pipx to install conan if not already installed

--- a/docs/build/quick_start.md
+++ b/docs/build/quick_start.md
@@ -1,5 +1,8 @@
 # Quick Start for Developers
 
+!!! note
+    The sc-machine can't be built on Windows.
+
 This guide provides short information for developers to start to work with sc-machine quickly. You can always learn more about the sc-machine's [build system](build_system.md).
 
 ## Check CMake
@@ -19,6 +22,7 @@ To upgrade CMake, run:
 pipx install cmake
 pipx ensurepath
 # relaunch your shell after installation
+exec $SHELL
 ```
 
 Install Ninja generator for CMake, to use sc-machine CMake presets:
@@ -28,6 +32,7 @@ Install Ninja generator for CMake, to use sc-machine CMake presets:
 pipx install ninja
 pipx ensurepath
 # relaunch your shell after installation
+exec $SHELL
 ```
 
 ## Start develop sc-machine with Conan
@@ -41,6 +46,7 @@ Install Conan, to build sc-machine with Conan-provided dependencies:
 pipx install conan
 pipx ensurepath
 # relaunch your shell after installation
+exec $SHELL
 ```
 
 ### Use sc-machine in Debug

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,5 +1,8 @@
 # Quick Start
 
+!!! note
+    The sc-machine can't be used on Windows.
+
 ## Use sc-machine as a C++ library in your project
 
 ### Conan
@@ -15,7 +18,7 @@ You can use Conan to install sc-machine. To integrate sc-machine into your proje
 
 2. Install pipx first using guide: https://pipx.pypa.io/stable/installation/.
 
-3. Install Conan if not already install:
+3. Install Conan if not already installed:
 
     ```sh
     pipx install conan
@@ -23,6 +26,10 @@ You can use Conan to install sc-machine. To integrate sc-machine into your proje
     ```
 
 4. Relaunch your shell after installation.
+
+    ```sh
+    exec $SHELL
+    ```
 
 5. Add the OSTIS-AI remote Conan repository:
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -4,44 +4,48 @@
 
 ### Conan
 
-You can use Conan to install sc-machine. To do this you need to create `conanfile.txt` in the root of the project and add to it:
+You can use Conan to install sc-machine. To integrate sc-machine into your project using Conan, follow these steps:
 
-```ini
-[requires]
-sc-machine/<version>
-```
+1. Create a `conanfile.txt` in your project root with the following content:
 
-Install Conan, to install sc-machine and Conan-provided dependencies:
+    ```ini
+    [requires]
+    sc-machine/<version>
+    ```
 
-```sh
-# Use pipx to install conan if not already installed
-# Install pipx first using guide: https://pipx.pypa.io/stable/installation/
-pipx install conan
-pipx ensurepath
-# relaunch your shell after installation
-```
+2. Install pipx first using guide: https://pipx.pypa.io/stable/installation/.
 
-Add remote repository to your Conan client configuration:
+3. Install Conan if not already install:
 
-```sh
-conan remote add ostis-ai https://conan.ostis.net/artifactory/api/conan/ostis-ai-sc-machine
-```
+    ```sh
+    pipx install conan
+    pipx ensurepath
+    ```
 
-Then run the following command in the project root:
+4. Relaunch your shell after installation.
 
-```sh
-conan install . --build=missing
-```
+5. Add the OSTIS-AI remote Conan repository:
 
-Import sc-machine targets into your CMake project by using:
+    ```sh
+    conan remote add ostis-ai https://conan.ostis.net/artifactory/api/conan/ostis-ai-sc-machine
+    ```
 
-```cmake
-find_package(sc-machine REQUIRED)
-```
+6. Install sc-machine and its dependencies:
 
-Start building! Refer to our [C++ Guide](sc-memory/api/cpp/guides/simple_guide_for_implementing_agent.md) on how to quickly develop an sc-machine agent in C++ from scratch.
+    ```sh
+    conan install . --build=missing
+    ```
+
+7. Import sc-machine targets into your CMake project by using:
+
+    ```cmake
+    find_package(sc-machine REQUIRED)
+    ```
+
+8. Start building! Refer to our [C++ Guide](sc-memory/api/cpp/guides/simple_guide_for_implementing_agent.md) on how to quickly develop an sc-machine agent in C++ from scratch.
 
 ### GitHub Releases
+
 You can download pre-built artifacts from [GitHub Releases](https://github.com/ostis-ai/sc-machine/releases). Extract it to any location, then make it available to CMake by appending folder path to `CMAKE_PREFIX_PATH`:
 
 ```cmake

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -11,6 +11,16 @@ You can use Conan to install sc-machine. To do this you need to create `conanfil
 sc-machine/<version>
 ```
 
+Install Conan, to install sc-machine and Conan-provided dependencies:
+
+```sh
+# Use pipx to install conan if not already installed
+# Install pipx first using guide: https://pipx.pypa.io/stable/installation/
+pipx install conan
+pipx ensurepath
+# relaunch your shell after installation
+```
+
 Add remote repository to your Conan client configuration:
 
 ```sh


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/CONTRIBUTING.md)
* [ ] Update changelog
* [x] Update documentation

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update documentation to include `pipx` and `conan` installation instructions for `sc-machine` setup.
> 
>   - **Documentation Updates**:
>     - Add instructions for installing `pipx` and `conan` in `docs/build/quick_start.md` and `docs/quick_start.md`.
>     - Update `docs/build/build_system.md` to include `exec $SHELL` after `pipx` installations.
>   - **Environment Setup**:
>     - Ensure `pipx` is installed before installing `cmake`, `ninja`, and `conan`.
>     - Add steps to relaunch shell after `pipx` installations for environment variable updates.
>   - **Miscellaneous**:
>     - Add note about Windows compatibility in `docs/build/quick_start.md` and `docs/quick_start.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for b547a4a2796913fbb455cf64da332577db769653. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->