### PR TITLE
[build][conan] Optimize using libxml2 dependency

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -32,11 +32,11 @@ class sc_machineRecipe(ConanFile):
         self.requires("websocketpp/0.8.2", options={"asio": "standalone"})
         self.requires("nlohmann_json/3.11.3")
         self.requires("glib/2.76.3")
+        self.requires("libxml2/2.13.4", options={"zlib": False, "iconv": False})
         # TODO(FallenChromium): use this instead of thirdparty/antlr4 
         # self.requires("antlr4-cppruntime/4.9.3")
 
     def build_requirements(self):
-        self.build_requires("libxml2/2.13.4")
         self.test_requires("gtest/1.14.0")
         self.test_requires("benchmark/1.9.0")
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Don't install transitive dependencies of libxml2: zlib and iconv
 - Fix typos in C++ Simple Guide for Implementing Agent and User permissions API
 - Migration script does not affect agent logs
 

--- a/sc-tools/sc-builder/CMakeLists.txt
+++ b/sc-tools/sc-builder/CMakeLists.txt
@@ -15,7 +15,6 @@ target_link_libraries(sc-builder-lib
     LINK_PRIVATE LibXml2::LibXml2
 )
 target_include_directories(sc-builder-lib
-    PRIVATE ${glib_INCLUDE_DIRS}
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     PUBLIC $<INSTALL_INTERFACE:include>

--- a/sc-tools/sc-builder/src/gwf_parser.hpp
+++ b/sc-tools/sc-builder/src/gwf_parser.hpp
@@ -12,8 +12,8 @@
 #include <memory>
 #include <list>
 
-#include <libxml2/libxml/parser.h>
-#include <libxml2/libxml/tree.h>
+#include <libxml/parser.h>
+#include <libxml/tree.h>
 
 #include "gwf_translator_constants.hpp"
 #include "sc_scg_element.hpp"

--- a/sc-tools/sc-builder/src/gwf_translator_constants.hpp
+++ b/sc-tools/sc-builder/src/gwf_translator_constants.hpp
@@ -9,7 +9,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include <libxml2/libxml/xmlstring.h>
+#include <libxml/xmlstring.h>
 
 namespace Constants
 {


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/CONTRIBUTING.md)
* [x] Update changelog
* [ ] Update documentation

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Optimize `libxml2` dependency usage by moving it to `requires` and updating include paths, avoiding transitive dependencies.
> 
>   - **Dependencies**:
>     - Move `libxml2` from `build_requires` to `requires` in `conanfile.py` with options to not install `zlib` and `iconv`.
>     - Update `gwf_parser.hpp` and `gwf_translator_constants.hpp` to use `<libxml/...>` instead of `<libxml2/libxml/...>`.
>   - **Build System**:
>     - Remove `${glib_INCLUDE_DIRS}` from `target_include_directories` in `sc-builder/CMakeLists.txt`.
>   - **Changelog**:
>     - Add entry for not installing transitive dependencies of `libxml2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for 301b01cdccad8da27abc67a5cb31a8e02e81dc86. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->