### PR TITLE
[docs] Fix typos in C++ Simple Guide for Implementing Agent and User permissions API

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Migration script does not affect agent logs.
+- Fix typos in C++ Simple Guide for Implementing Agent and User permissions API
+- Migration script does not affect agent logs
 
 ## [0.10.0] - 21.01.2025
 

--- a/docs/sc-memory/api/cpp/extended/permissions_api.md
+++ b/docs/sc-memory/api/cpp/extended/permissions_api.md
@@ -73,10 +73,10 @@ To unidentify identified user, you can create reverse connection between specifi
 
 Users can be known in advance and then guest users and their identification is unnecessary, but all users should be authenticated in sc-memory. User authentication involves the process of verifying the authenticity of identified user and storing information about that user in sc-memory.
 
-To authenticate user in sc-memory, you should create connection between `concept_authentication_request` and user:
+To authenticate user in sc-memory, you should create connection between `concept_authentication_request_user` and user:
 
 ```scs
-concept_authentication_request -> ..some_user;;
+concept_authentication_request_user -> ..some_user;;
 ```
 
 You should do it once, no more. After the sc-machine authenticates this user, it means that connection between `concept_authenticated_user` and user has been created and all contexts with this user have been authenticated.
@@ -147,7 +147,7 @@ After, you can authenticate identified user.
 
 ### **Example of user authentication**
 
-To do this programly you can create waiter to wait sc-event of adding outgoing sc-arc from `concept_authenticated_user` and request user to be authenticated, i.e. create sc-arc between `concept_authentication_request` and user. After waiting this sc-event, your user will be authenticated.
+To do this programly you can create waiter to wait sc-event of adding outgoing sc-arc from `concept_authenticated_user` and request user to be authenticated, i.e. create sc-arc between `concept_authentication_request_user` and user. After waiting this sc-event, your user will be authenticated.
 
 ```cpp
 ...
@@ -175,7 +175,7 @@ auto eventWaiter
   {
     ScMemory::ms_globalContext->GenerateConnector(
       ScType::ConstPermPosArc, 
-      ScKeynodes::concept_authentication_request, 
+      ScKeynodes::concept_authentication_request_user, 
       userAddr1);
 
     // Only `ScMemory::ms_globalContext` can authenticate users.


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/CONTRIBUTING.md)
* [x] Update changelog
* [x] Update documentation

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typos in C++ Simple Guide for Implementing Agent and User permissions API documentation.
> 
>   - **Documentation**:
>     - Fix typos in `permissions_api.md` by correcting `concept_authentication_request` to `concept_authentication_request_user`.
>     - Fix typos in `simple_guide_for_implementing_agent.md` by changing `size_t` to `uint32_t` for `setPower` and renaming `arcAccessAddr` to `membershipArcAddr`.
>   - **Misc**:
>     - Update `changelog.md` to include typo fixes in the C++ Simple Guide for Implementing Agent and User permissions API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for 64fa97522cc6639a3393f6df79b3776c8acea55a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->