### PR TITLE
[docs] Use Latin `c` instead of Cyrillic `с`

### DIFF
--- a/docs/sc-memory/api/cpp/guides/simple_guide_for_implementing_agent.md
+++ b/docs/sc-memory/api/cpp/guides/simple_guide_for_implementing_agent.md
@@ -61,7 +61,7 @@ set-agents-module/
 ├── CMakeLists.txt
 ├── agent/
 │   ├── sc_agent_calculate_set_power.hpp
-│   └── sc_agent_calculate_set_power.сpp
+│   └── sc_agent_calculate_set_power.cpp
 ```
 
 ---
@@ -234,7 +234,7 @@ set-agents-module/
  ├── CMakeLists.txt
  ├── agent/
  │   ├── sc_agent_calculate_set_power.hpp
- │   └── sc_agent_calculate_set_power.сpp
+ │   └── sc_agent_calculate_set_power.cpp
 +├── keynodes/
 +│   └── sc_set_keynodes.hpp
 ```
@@ -331,7 +331,7 @@ Someone should subscribe your agent to event. It can be other agent, or any code
  ├── CMakeLists.txt
  ├── agent/
  │   ├── sc_agent_calculate_set_power.hpp
- │   └── sc_agent_calculate_set_power.сpp
+ │   └── sc_agent_calculate_set_power.cpp
  ├── keynodes/
  │   └── sc_set_keynodes.hpp
 +├── sc_set_module.hpp
@@ -413,7 +413,7 @@ To make sure how your agent works it is best to generate tests and cover in them
  ├── CMakeLists.txt
  ├── agent/
  │   ├── sc_agent_calculate_set_power.hpp
- │   └── sc_agent_calculate_set_power.сpp
+ │   └── sc_agent_calculate_set_power.cpp
  ├── keynodes/
  │   └── sc_set_keynodes.hpp
 +├── tests/


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/CONTRIBUTING.md)
* [ ] Update changelog
* [ ] Update documentation

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo by replacing Cyrillic `с` with Latin `c` in file path in `simple_guide_for_implementing_agent.md`.
> 
>   - **Documentation**:
>     - Replace Cyrillic `с` with Latin `c` in `sc_agent_calculate_set_power.cpp` file path in `simple_guide_for_implementing_agent.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for ae2f79854d079c27f9efc3f675e2f9c303053461. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->