### PR TITLE
[memory] Update log level for color info log

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SC_LOG_INFO_COLOR uses correct enum value
 - Move CONTRIBUTING.md to docs folder
 - Don't install transitive dependencies of libxml2: zlib and iconv
 - Fix typos in C++ Simple Guide for Implementing Agent and User permissions API

--- a/sc-memory/sc-memory/include/sc-memory/utils/sc_logger.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/utils/sc_logger.hpp
@@ -294,4 +294,4 @@ static utils::ScLogger ms_globalLogger;
  *
  * Usage: SC_LOG_INFO_COLOR("Custom info", customColor);
  */
-#define SC_LOG_INFO_COLOR(__message, __color) ({SC_LOG_COLOR(::utils::ScLogType::Info, __message, __color)})
+#define SC_LOG_INFO_COLOR(__message, __color) ({SC_LOG_COLOR(utils::ScLogLevel::Level::Info, __message, __color)})


### PR DESCRIPTION
* [X] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/CONTRIBUTING.md)
* [x] Update changelog
* [ ] Update documentation

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `SC_LOG_INFO_COLOR` macro in `sc_logger.hpp` to use correct log level enumeration.
> 
>   - **Macro Update**:
>     - In `sc_logger.hpp`, update `SC_LOG_INFO_COLOR` macro to use `utils::ScLogLevel::Level::Info` instead of `::utils::ScLogType::Info`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for c1ce02b3141aafc62f062d6475443eedb8ee4a46. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->