### PR TITLE
[docs] Fix grammar in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -116,9 +116,8 @@ All commits that not follow these rules should be split according to these rules
 
 ### Pull Request Review
 
- - Reviewer should test code from PR if CI doesn't do it;
- - Reviewer submit review as set of conversations;
- - Author make review fixes at `Review fixes` commits;
- - Author re-request review;
- - Reviewer resolve conversations if they were fixed and approve PR.
-
+ - Reviewer tests code from PR if CI doesn't do it;
+ - Reviewer submits review as set of conversations;
+ - Author makes review fixes at `Review fixes` commits;
+ - Author re-requests review;
+ - Reviewer resolves conversations and approves PR if conversations were fixed.


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/CONTRIBUTING.md)
* [ ] Update changelog
* [x] Update documentation

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes grammar in `CONTRIBUTING.md` Pull Request Review section for clarity.
> 
>   - **Documentation**:
>     - Fixes grammar in `CONTRIBUTING.md` under the Pull Request Review section.
>     - Changes include correcting verb forms: "Reviewer should test" to "Reviewer tests", "Reviewer submit" to "Reviewer submits", "Author make" to "Author makes", "Author re-request" to "Author re-requests", and "Reviewer resolve" to "Reviewer resolves".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for 7de385bda1498e99f1e1feae615c43d57c1748bf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->