### PR TITLE
[kpm][scn2json] Fix translating sc-structures to json

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Translating sc-structures to json in scn2json-translator
 - Take into account order relations between sc-elements in quasibinary tuples in scn2json-translator
 - SC_LOG_INFO_COLOR uses correct enum value
 - Move CONTRIBUTING.md to docs folder

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Translating sc-structures to json in scn2json-translator
-- Take into account order relations between sc-elements in quasibinary tuples in scn2json-translator
+- Translating sc-structures to json in sc2scn-json-translator
+- Take into account order relations between sc-elements in quasibinary tuples in sc2scn-json-translator
 - SC_LOG_INFO_COLOR uses correct enum value
 - Move CONTRIBUTING.md to docs folder
 - Don't install transitive dependencies of libxml2: zlib and iconv

--- a/sc-kpm/sc-ui/src/translators/uiSc2SCnJsonTranslator.cpp
+++ b/sc-kpm/sc-ui/src/translators/uiSc2SCnJsonTranslator.cpp
@@ -167,7 +167,7 @@ void uiSc2SCnJsonTranslator::CollectScStructureElementsInfo()
   for (auto const & keyword : mKeywordsList)
   {
     elInfo = ResolveStructureElementInfo(keyword);
-    if (elInfo->type & sc_type_node_structure)
+    if ((elInfo->type & sc_type_node_structure) == sc_type_node_structure)
     {
       // get the key elements of the structure
       ScStructureElementInfo::ScStructureElementInfoList keynodes;
@@ -195,8 +195,9 @@ void uiSc2SCnJsonTranslator::CollectScStructureElementsInfo()
       ScStructureElementInfo::ScStructureElementInfoList removableArcs;
       for (auto const & elInfoOutputArc : elInfo->outputArcs)
       {
-        // find structure elements by arc_pos_const_perm without modifiers
-        if (!(elInfoOutputArc->type & sc_type_const_perm_pos_arc && elInfoOutputArc->inputArcs.empty()))
+        // find structure elements by const_perm_pos_arc without modifiers
+        if (!((elInfoOutputArc->type & sc_type_const_perm_pos_arc) == sc_type_const_perm_pos_arc
+              && elInfoOutputArc->inputArcs.empty()))
           continue;
 
         structureElementIt = elInfoOutputArc->targetInfo->inputArcs.find(elInfoOutputArc);
@@ -248,7 +249,7 @@ ScStructureElementInfo * uiSc2SCnJsonTranslator::FindStructureKeyword(
       structureElements.cend(),
       [&structures](ScStructureElementInfo * el)
       {
-        if (el->type & sc_type_node_structure)
+        if ((el->type & sc_type_node_structure) == sc_type_node_structure)
           structures.insert(el);
       });
   if (!structures.empty())
@@ -295,7 +296,7 @@ void uiSc2SCnJsonTranslator::ParseScnJsonLink(ScStructureElementInfo * elInfo, S
       for (std::string_view const & formatStr : ScnTranslatorConstants::formats)
       {
         sc_helper_resolve_system_identifier(s_default_ctx, formatStr.data(), &format);
-        if (sc_helper_check_arc(s_default_ctx, elInfo->addr, format, sc_type_common_arc | sc_type_const) == SC_TRUE)
+        if (sc_helper_check_arc(s_default_ctx, elInfo->addr, format, sc_type_const_common_arc) == SC_TRUE)
         {
           contentType = formatStr.data();
           break;
@@ -342,7 +343,7 @@ void uiSc2SCnJsonTranslator::ParseScnJsonSentence(
     ParseScnJsonLink(elInfo, result);
   }
   // if the nesting level is not greater than the maximum or the element is not a tuple, get children
-  if (level < maxLevel || (elInfo->type & sc_type_node & sc_type_node_tuple))
+  if (level < maxLevel || ((elInfo->type & sc_type_node_tuple) == sc_type_node_tuple))
   {
     auto & resultChildren = result[ScnTranslatorConstants::CHILDREN.data()];
     // first get children from ordered list of modifiers
@@ -687,7 +688,8 @@ void uiSc2SCnJsonTranslator::ParseScnJsonChild(
 
   auto modifierIt = modifiersList.begin();
   ScJson modifier = ScJson();
-  if (modifierIt != modifiersList.end() && !((*modifierIt)->isInTree))
+  if (modifierIt != modifiersList.end() && !((*modifierIt)->isInTree)
+      && ((*modifierIt)->sourceInfo->type & sc_type_node_structure) != sc_type_node_structure)
   {
     ParseScElementInfo((*modifierIt)->sourceInfo, modifier);
     ScJson modifierEl;

--- a/sc-kpm/sc-ui/src/translators/uiSc2SCnJsonTranslator.cpp
+++ b/sc-kpm/sc-ui/src/translators/uiSc2SCnJsonTranslator.cpp
@@ -167,7 +167,7 @@ void uiSc2SCnJsonTranslator::CollectScStructureElementsInfo()
   for (auto const & keyword : mKeywordsList)
   {
     elInfo = ResolveStructureElementInfo(keyword);
-    if ((elInfo->type & sc_type_node_structure) == sc_type_node_structure)
+    if (sc_type_has_subtype(elInfo->type, sc_type_node_structure))
     {
       // get the key elements of the structure
       ScStructureElementInfo::ScStructureElementInfoList keynodes;
@@ -196,7 +196,7 @@ void uiSc2SCnJsonTranslator::CollectScStructureElementsInfo()
       for (auto const & elInfoOutputArc : elInfo->outputArcs)
       {
         // find structure elements by const_perm_pos_arc without modifiers
-        if (!((elInfoOutputArc->type & sc_type_const_perm_pos_arc) == sc_type_const_perm_pos_arc
+        if (!(sc_type_has_subtype(elInfoOutputArc->type, sc_type_const_perm_pos_arc)
               && elInfoOutputArc->inputArcs.empty()))
           continue;
 
@@ -249,7 +249,7 @@ ScStructureElementInfo * uiSc2SCnJsonTranslator::FindStructureKeyword(
       structureElements.cend(),
       [&structures](ScStructureElementInfo * el)
       {
-        if ((el->type & sc_type_node_structure) == sc_type_node_structure)
+        if (sc_type_has_subtype(el->type, sc_type_node_structure))
           structures.insert(el);
       });
   if (!structures.empty())
@@ -343,7 +343,7 @@ void uiSc2SCnJsonTranslator::ParseScnJsonSentence(
     ParseScnJsonLink(elInfo, result);
   }
   // if the nesting level is not greater than the maximum or the element is not a tuple, get children
-  if (level < maxLevel || ((elInfo->type & sc_type_node_tuple) == sc_type_node_tuple))
+  if (level < maxLevel || sc_type_has_subtype(elInfo->type, sc_type_node_tuple))
   {
     auto & resultChildren = result[ScnTranslatorConstants::CHILDREN.data()];
     // first get children from ordered list of modifiers
@@ -520,7 +520,7 @@ void uiSc2SCnJsonTranslator::ParseLinkedNodesScnJson(ScJson & children, int leve
           SC_ADDR_LOCAL_SEG_FROM_INT(addr_hash), SC_ADDR_LOCAL_OFFSET_FROM_INT(addr_hash)};
 
       ScStructureElementInfo * linkedNodeInfo = mStructureElementsInfo[linkedNodeAddr];
-      if ((linkedNodeInfo->type & sc_type_node_structure) != sc_type_node_structure)
+      if (sc_type_has_not_subtype(linkedNodeInfo->type, sc_type_node_structure))
       {
         ParseScnJsonSentence(linkedNodeInfo, level, isStruct, linkedNode);
       }
@@ -689,7 +689,7 @@ void uiSc2SCnJsonTranslator::ParseScnJsonChild(
   auto modifierIt = modifiersList.begin();
   ScJson modifier = ScJson();
   if (modifierIt != modifiersList.end() && !((*modifierIt)->isInTree)
-      && ((*modifierIt)->sourceInfo->type & sc_type_node_structure) != sc_type_node_structure)
+      && sc_type_has_not_subtype((*modifierIt)->sourceInfo->type, sc_type_node_structure))
   {
     ParseScElementInfo((*modifierIt)->sourceInfo, modifier);
     ScJson modifierEl;
@@ -714,14 +714,14 @@ void uiSc2SCnJsonTranslator::ResolveFilterList(sc_addr cmd_addr)
       s_default_ctx,
       cmd_addr,
       sc_type_const_perm_pos_arc,
-      sc_type_node | sc_type_const,
+      sc_type_const_node,
       sc_type_const_perm_pos_arc,
       keynode_rrel_filter_list);
 
   while (sc_iterator5_next(it) == SC_TRUE)
   {
     modifierIt = sc_iterator3_f_a_a_new(
-        s_default_ctx, sc_iterator5_value(it, 2), sc_type_const_perm_pos_arc, sc_type_node | sc_type_const);
+        s_default_ctx, sc_iterator5_value(it, 2), sc_type_const_perm_pos_arc, sc_type_const_node);
     while (sc_iterator3_next(modifierIt) == SC_TRUE)
     {
       mFilterList.insert(sc_iterator3_value(modifierIt, 2));
@@ -736,10 +736,7 @@ void uiSc2SCnJsonTranslator::InitFilterList()
 {
   // init filter list
   sc_iterator3 * it = sc_iterator3_f_a_a_new(
-      s_default_ctx,
-      keynode_concept_scn_json_elements_filter_set,
-      sc_type_const_perm_pos_arc,
-      sc_type_node | sc_type_const);
+      s_default_ctx, keynode_concept_scn_json_elements_filter_set, sc_type_const_perm_pos_arc, sc_type_const_node);
 
   while (sc_iterator3_next(it) == SC_TRUE)
   {
@@ -757,7 +754,7 @@ void uiSc2SCnJsonTranslator::InitOrderList()
       s_default_ctx,
       keynode_concept_scn_json_elements_order_set,
       sc_type_const_perm_pos_arc,
-      sc_type_node | sc_type_const,
+      sc_type_const_node,
       sc_type_const_perm_pos_arc,
       keynode_rrel_1);
 
@@ -768,7 +765,7 @@ void uiSc2SCnJsonTranslator::InitOrderList()
     while (!SC_ADDR_IS_EMPTY(elementArc))
     {
       elementIt = sc_iterator3_f_f_a_new(
-          s_default_ctx, keynode_concept_scn_json_elements_order_set, elementArc, sc_type_node | sc_type_const);
+          s_default_ctx, keynode_concept_scn_json_elements_order_set, elementArc, sc_type_const_node);
       if (sc_iterator3_next(elementIt) == SC_TRUE)
       {
         mOrderList.push_back(sc_iterator3_value(elementIt, 2));

--- a/sc-kpm/sc-ui/src/translators/uiSc2SCnJsonTranslator.h
+++ b/sc-kpm/sc-ui/src/translators/uiSc2SCnJsonTranslator.h
@@ -117,7 +117,7 @@ private:
   //! Store structure elements if keyword is struct to remove them from keyword childrens
   ScStructureElementInfo::ScStructureElementInfoList structureElements;
   //! Max level of full discripted node
-  int const maxLevel = 10;
+  int const maxLevel = 3;
 };
 
 #endif  // _uiSc2SCnJsonTranslator_h_


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/CONTRIBUTING.md)
* [x] Update changelog
* [ ] Update documentation

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes translation of sc-structures to JSON in `uiSc2SCnJsonTranslator`, considering order relations in quasibinary tuples.
> 
>   - **Behavior**:
>     - Fix translation of sc-structures to JSON in `uiSc2SCnJsonTranslator`.
>     - Consider order relations in quasibinary tuples during translation.
>   - **Code Changes**:
>     - Replace bitwise operations with `sc_type_has_subtype()` in `uiSc2SCnJsonTranslator.cpp` to check sc-element types.
>     - Adjust `maxLevel` from 10 to 3 in `uiSc2SCnJsonTranslator.h`.
>     - Modify `ParseScnJsonLink()` to use `sc_type_const_common_arc`.
>   - **Changelog**:
>     - Update changelog to reflect fixes in JSON translation and order relations handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for b8a76758d98ab6397462ca89b228c170df446f6c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->