### PR TITLE
[docs] Use --dev flag during launching install_deps_ubuntu.sh in quick_start.md

### DIFF
--- a/docs/build/quick_start.md
+++ b/docs/build/quick_start.md
@@ -151,7 +151,7 @@ You can also check code formatting, build sc-machine with sanitizers and other. 
 
 ```sh
 cd scripts
-./install_deps_ubuntu.sh
+./install_deps_ubuntu.sh --dev
 ```
 
 #### Install sc-machine dependencies for macOS

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add using --dev flag during launching install_deps_ubuntu.sh in quick_start for users
+
 ## [0.10.1] - 15.03.2025
 
 ### Added


### PR DESCRIPTION


* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/CONTRIBUTING.md)
* [x] Update changelog
* [x] Update documentation

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `quick_start.md` to include `--dev` flag for `install_deps_ubuntu.sh` and reflect this in `changelog.md`.
> 
>   - **Documentation**:
>     - Update `quick_start.md` to use `--dev` flag with `install_deps_ubuntu.sh`.
>     - Update `changelog.md` to reflect the addition of `--dev` flag in `quick_start.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for 7d8374e5a9a5917bc6bfac3241deac931e43dcd7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->