### PR TITLE
Check format with iterator

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Manually check format of sc-links in uiSc2SCnJsonTranslator
+
 ## [0.10.2] - 22.04.2025
 
 ### Added

--- a/sc-kpm/sc-ui/src/uiTypes.h
+++ b/sc-kpm/sc-ui/src/uiTypes.h
@@ -38,6 +38,7 @@ typedef std::list<sc_addr> tScAddrList;
 typedef std::vector<sc_addr> tScAddrVector;
 typedef std::map<sc_addr, sc_type> tScAddrToScTypeMap;
 typedef std::map<sc_addr, sc_addr> tScAddrToScAddrMap;
+typedef std::map<sc_addr, String> tScAddrToStringMap;
 typedef std::pair<sc_addr, sc_addr> tScAddrPair;
 typedef std::list<tScAddrPair> tScAddrPairList;
 typedef std::map<String, String> tStringStringMap;


### PR DESCRIPTION
* [X] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/CONTRIBUTING.md)
* [X] Update changelog
* [X] Update documentation

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Manually check sc-link formats in `uiSc2SCnJsonTranslator` using an iterator for improved efficiency.
> 
>   - **Behavior**:
>     - Manually check format of sc-links in `uiSc2SCnJsonTranslator` using an iterator.
>     - Update `uiSc2SCnJsonTranslator::ParseScnJsonLink()` to use `formats_keynodes` for format checking.
>   - **Data Structures**:
>     - Add `tScAddrToStringMap` typedef in `uiTypes.h` for mapping sc_addr to strings.
>     - Initialize `formats_keynodes` in `uiSc2SCnJsonTranslator::runImpl()`.
>   - **Documentation**:
>     - Update `changelog.md` to reflect the manual format check for sc-links.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for 380d1519e98060e49d12afa1caababaf537a99c6. You can [customize](https://app.ellipsis.dev/ostis-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->