### PR TITLE
[build] Make temporary override for libffi until updated in conan-center-index

### DIFF
--- a/.github/workflows/test_conan.yml
+++ b/.github/workflows/test_conan.yml
@@ -63,6 +63,8 @@ jobs:
       - name: Build sc-machine with tests
         id: run_cmake
         run: |
+          # ostis-ai hosts libffi 3.4.8
+          conan remote add ostis-ai https://conan.ostis.net/artifactory/api/conan/ostis-ai-library/
           cmake --preset release-with-tests-conan
           cmake --build --preset release
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -33,6 +33,9 @@ class sc_machineRecipe(ConanFile):
         self.requires("nlohmann_json/3.11.3")
         self.requires("glib/2.76.3")
         self.requires("libxml2/2.13.4", options={"zlib": False, "iconv": False})
+        # TODO(NikitaZotov): Temporary override for libffi until updated in conan-center-index.
+        # This ensures consistent version usage across glib.
+        self.requires("libffi/3.4.8", override=True) 
         # TODO(FallenChromium): use this instead of thirdparty/antlr4 
         # self.requires("antlr4-cppruntime/4.9.3")
 

--- a/docs/build/build_system.md
+++ b/docs/build/build_system.md
@@ -73,6 +73,10 @@ pipx install conan
 ```
 
 ```sh
+conan remote add ostis-ai https://conan.ostis.net/artifactory/api/conan/ostis-ai-library/
+```
+
+```sh
 # Use preset with Conan-provided dependencies and debug build type
 cmake --preset debug-conan
 # Use debug build preset since we've used a debug configure preset

--- a/docs/build/quick_start.md
+++ b/docs/build/quick_start.md
@@ -59,6 +59,12 @@ pipx ensurepath
 exec $SHELL
 ```
 
+Add the 'ostis-ai' remote, enabling Conan to find packages (libffi/3.4.8):
+
+```sh
+conan remote add ostis-ai https://conan.ostis.net/artifactory/api/conan/ostis-ai-library/
+```
+
 ### Use sc-machine in Debug
 
 #### Build sc-machine in Debug

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Pin asio version for macOS native installation
+- Make temporary override for libffi in ostis-ai until updated in conan-center-index
+- Pin asio version 3.10.2 for macOS native installation
 
 ## [0.10.2] - 22.04.2025
 


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/CONTRIBUTING.md)
* [x] Update changelog
* [x] Update documentation

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add temporary override for `libffi` version 3.4.8 using `ostis-ai` Conan remote to ensure compatibility with `glib`.
> 
>   - **Conan Configuration**:
>     - Add `ostis-ai` remote in `.github/workflows/test_conan.yml` and `conanfile.py` for `libffi/3.4.8`.
>     - Override `libffi` version to `3.4.8` in `conanfile.py` to ensure compatibility with `glib`.
>   - **Documentation**:
>     - Update `build_system.md` and `quick_start.md` to include instructions for adding the `ostis-ai` remote.
>   - **Changelog**:
>     - Document temporary override for `libffi` in `changelog.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for bcd91205594e56e6e44d3b68705c6944ad206ba3. You can [customize](https://app.ellipsis.dev/ostis-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->