### PR TITLE
[scripts] Pin asio version for macOS native installation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pin asio version for macOS native installation
+
 ## [0.10.2] - 22.04.2025
 
 ### Added

--- a/scripts/install_deps_macOS.sh
+++ b/scripts/install_deps_macOS.sh
@@ -5,8 +5,8 @@ SCRIPTS_PATH="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
 
 brew install glib temurin pkgconfig cmake ninja ccache websocketpp nlohmann-json libxml2 googletest google-benchmark
 
-# TODO(NikitaZotov): websocketpp 0.8.2 support asio 1.30.2 only. Remove it after releasing new version of websocketpp.
-brew uninstall asio
+# TODO(NikitaZotov): websocketpp 0.8.2 supports asio 1.30.2 only. Remove it after releasing new version of websocketpp.
+brew uninstall --ignore-dependencies asio
 curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/502489d3a4c1ca0a3854830eb5da2327b6feb54d/Formula/a/asio.rb
 brew install asio.rb
 brew pin asio

--- a/scripts/install_deps_macOS.sh
+++ b/scripts/install_deps_macOS.sh
@@ -3,6 +3,9 @@ set -eo pipefail
 
 SCRIPTS_PATH="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
 
-brew install glib temurin pkgconfig cmake ninja ccache asio websocketpp nlohmann-json libxml2 googletest google-benchmark
+brew install glib temurin pkgconfig cmake ninja ccache websocketpp nlohmann-json libxml2 googletest google-benchmark
+
+curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/502489d3a4c1ca0a3854830eb5da2327b6feb54d/Formula/a/asio.rb
+brew install asio.rb
 
 "${SCRIPTS_PATH}/install_deps_python.sh"

--- a/scripts/install_deps_macOS.sh
+++ b/scripts/install_deps_macOS.sh
@@ -5,7 +5,9 @@ SCRIPTS_PATH="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
 
 brew install glib temurin pkgconfig cmake ninja ccache websocketpp nlohmann-json libxml2 googletest google-benchmark
 
-# TODO(NikitaZotov): websocketpp 0.8.2 supports asio 1.30.2 only. Remove it after releasing new version of websocketpp.
+# TODO(NikitaZotov): Remove asio version 1.30.2 pinning below.
+# Required because websocketpp 0.8.2 is incompatible with newer asio.
+# Remove after updating websocketpp to a version including the fix from PR https://github.com/zaphoyd/websocketpp/pull/1164 or later.
 brew uninstall --ignore-dependencies asio
 curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/502489d3a4c1ca0a3854830eb5da2327b6feb54d/Formula/a/asio.rb
 brew install asio.rb

--- a/scripts/install_deps_macOS.sh
+++ b/scripts/install_deps_macOS.sh
@@ -5,7 +5,10 @@ SCRIPTS_PATH="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
 
 brew install glib temurin pkgconfig cmake ninja ccache websocketpp nlohmann-json libxml2 googletest google-benchmark
 
+# TODO(NikitaZotov): websocketpp 0.8.2 support asio 1.30.2 only. Remove it after releasing new version of websocketpp.
+brew uninstall asio
 curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/502489d3a4c1ca0a3854830eb5da2327b6feb54d/Formula/a/asio.rb
 brew install asio.rb
+brew pin asio
 
 "${SCRIPTS_PATH}/install_deps_python.sh"


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/CONTRIBUTING.md)
* [x] Update changelog
* [ ] Update documentation

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Pin `asio` version to 1.30.2 in `install_deps_macOS.sh` due to `websocketpp` incompatibility, with changelog update.
> 
>   - **Behavior**:
>     - Pin `asio` version to 1.30.2 in `install_deps_macOS.sh` due to incompatibility with `websocketpp` 0.8.2.
>     - Add a TODO comment to remove pinning after `websocketpp` update.
>   - **Documentation**:
>     - Update `changelog.md` to reflect the `asio` version pinning for macOS installation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for ee8c5700c4e1281a2fb2dd6c243112422fe81af9. You can [customize](https://app.ellipsis.dev/ostis-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->