### PR TITLE
[ci] Swap set conan remote and build sc-machine steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,16 +73,16 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install cmake ninja ccache
 
+      - name: Set Conan remote
+        run: |
+          conan remote add ostis-ai https://conan.ostis.net/artifactory/api/conan/ostis-ai-library/
+          conan remote login ostis-ai ${{ secrets.CONAN_USERNAME }} -p ${{ secrets.CONAN_API_KEY }}
+
       - name: Build sc-machine
         id: run_cmake
         run: |
           cmake --preset release-conan
           cmake --build --preset release
-
-      - name: Set Conan remote
-        run: |
-          conan remote add ostis-ai https://conan.ostis.net/artifactory/api/conan/ostis-ai-library/
-          conan remote login ostis-ai ${{ secrets.CONAN_USERNAME }} -p ${{ secrets.CONAN_API_KEY }}
 
       - name: Create Conan package
         run: |


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/CONTRIBUTING.md)
* [ ] Update changelog
* [ ] Update documentation

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Swaps `Set Conan remote` and `Build sc-machine` steps in CI workflow to ensure correct package access.
> 
>   - **CI Workflow**:
>     - Swaps the order of `Set Conan remote` and `Build sc-machine` steps in `.github/workflows/release.yml`.
>     - Ensures Conan remote is configured before building to access necessary packages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for 92b23bb689d6b197eb94eb6db624516e22f79a8e. You can [customize](https://app.ellipsis.dev/ostis-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->