### PR TITLE
[memory][utils][logger] Flag for ScLogger to enable appending logs to existing log file

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Flag for ScLogger to enable appending logs to existing log file
+
 ## [0.10.3] - 01.05.2025
 
 ### Fixed

--- a/sc-memory/sc-memory/include/sc-memory/utils/sc_logger.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/utils/sc_logger.hpp
@@ -94,13 +94,13 @@ public:
    * @param logType A type of logging (Console or File).
    * @param logFile A filename to log messages if logType is File.
    * @param logLevel An initial logging level.
-   * @param append A flag indicating whether to append to the file or overwrite it.
+   * @param appendMode A flag indicating whether to append to the file or overwrite it.
    */
   explicit ScLogger(
       ScLogType const & logType,
       std::string const & logFile,
       ScLogLevel const & logLevel,
-      bool append = false);
+      bool appendMode = false);
 
   /*!
    * @brief Copy constructor for the ScLogger class.
@@ -144,9 +144,8 @@ public:
    * @brief Opens a specified file for logging and sets it as the current log file.
    *
    * @param logFile A name of the file where logs should be written.
-   * @param append A flag indicating whether to append to the file or overwrite it.
    */
-  void SetLogFile(std::string const & logFile, bool append = false);
+  void SetLogFile(std::string const & logFile);
 
   /*!
    * @brief Changes severity level of the message being logged.
@@ -226,10 +225,11 @@ public:
   void Debug(T const & t, ARGS const &... others);
 
 protected:
-  bool m_isMuted;        //< Indicates whether logging is muted.
-  std::string m_prefix;  //< Prefix added to each logged message.
-  ScLogType m_logType;   //< Current type of logging (Console or File).
-  std::string m_logFile;
+  bool m_isMuted;         //< Indicates whether logging is muted.
+  std::string m_prefix;   //< Prefix added to each logged message.
+  ScLogType m_logType;    //< Current type of logging (Console or File).
+  std::string m_logFile;  //< Name of the file where logs should be written.
+  bool m_appendMode;      //< Flag indicating whether to append to the file or overwrite it.
 
 private:
   std::ofstream m_logFileStream;  //< Stream for writing logs to file if applicable.

--- a/sc-memory/sc-memory/include/sc-memory/utils/sc_logger.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/utils/sc_logger.hpp
@@ -94,6 +94,7 @@ public:
    * @param logType A type of logging (Console or File).
    * @param logFile A filename to log messages if logType is File.
    * @param logLevel An initial logging level.
+   * @param append A flag indicating whether to append to the file or overwrite it.
    */
   explicit ScLogger(
       ScLogType const & logType,

--- a/sc-memory/sc-memory/include/sc-memory/utils/sc_logger.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/utils/sc_logger.hpp
@@ -95,7 +95,11 @@ public:
    * @param logFile A filename to log messages if logType is File.
    * @param logLevel An initial logging level.
    */
-  explicit ScLogger(ScLogType const & logType, std::string const & logFile, ScLogLevel const & logLevel);
+  explicit ScLogger(
+      ScLogType const & logType,
+      std::string const & logFile,
+      ScLogLevel const & logLevel,
+      bool append = false);
 
   /*!
    * @brief Copy constructor for the ScLogger class.
@@ -139,8 +143,9 @@ public:
    * @brief Opens a specified file for logging and sets it as the current log file.
    *
    * @param logFile A name of the file where logs should be written.
+   * @param append A flag indicating whether to append to the file or overwrite it.
    */
-  void SetLogFile(std::string const & logFile);
+  void SetLogFile(std::string const & logFile, bool append = false);
 
   /*!
    * @brief Changes severity level of the message being logged.

--- a/sc-memory/sc-memory/src/utils/sc_logger.cpp
+++ b/sc-memory/sc-memory/src/utils/sc_logger.cpp
@@ -73,14 +73,15 @@ ScLogger::ScLogger(
     ScLogType const & logType,
     std::string const & logFile,
     ScLogLevel const & logLevel,
-    bool append /*= false*/)
+    bool appendMode /*= false*/)
   : m_isMuted(false)
   , m_logType(logType)
   , m_logFile(logFile)
   , m_logLevel(logLevel)
+  , m_appendMode(appendMode)
 {
   if (m_logType == ScLogType::File)
-    SetLogFile(m_logFile, append);
+    SetLogFile(m_logFile);
 }
 
 ScLogger::~ScLogger()
@@ -99,9 +100,10 @@ ScLogger & ScLogger::operator=(ScLogger const & other)
   {
     m_isMuted = other.m_isMuted;
     m_logType = other.m_logType;
+    m_logLevel = other.m_logLevel;
+    m_appendMode = other.m_appendMode;
     if (m_logType == ScLogType::File)
       SetLogFile(other.m_logFile);
-    m_logLevel = other.m_logLevel;
   }
   return *this;
 }
@@ -130,11 +132,11 @@ void ScLogger::SetPrefix(std::string const & prefix)
   m_prefix = prefix;
 }
 
-void ScLogger::SetLogFile(std::string const & logFile, bool append /*= false*/)
+void ScLogger::SetLogFile(std::string const & logFile)
 {
   Clear();
   m_logType = ScLogger::ScLogType::File;
-  m_logFileStream.open(logFile, std::ofstream::out | (append ? std::ofstream::app : std::ofstream::trunc));
+  m_logFileStream.open(logFile, std::ofstream::out | (m_appendMode ? std::ofstream::app : std::ofstream::trunc));
 }
 
 void ScLogger::SetLogLevel(ScLogLevel const & logLevel)

--- a/sc-memory/sc-memory/src/utils/sc_logger.cpp
+++ b/sc-memory/sc-memory/src/utils/sc_logger.cpp
@@ -69,14 +69,18 @@ ScLogger::ScLogger()
 {
 }
 
-ScLogger::ScLogger(ScLogType const & logType, std::string const & logFile, ScLogLevel const & logLevel)
+ScLogger::ScLogger(
+    ScLogType const & logType,
+    std::string const & logFile,
+    ScLogLevel const & logLevel,
+    bool append /*= false*/)
   : m_isMuted(false)
   , m_logType(logType)
   , m_logFile(logFile)
   , m_logLevel(logLevel)
 {
   if (m_logType == ScLogType::File)
-    SetLogFile(m_logFile);
+    SetLogFile(m_logFile, append);
 }
 
 ScLogger::~ScLogger()
@@ -126,11 +130,11 @@ void ScLogger::SetPrefix(std::string const & prefix)
   m_prefix = prefix;
 }
 
-void ScLogger::SetLogFile(std::string const & logFile)
+void ScLogger::SetLogFile(std::string const & logFile, bool append /*= false*/)
 {
   Clear();
   m_logType = ScLogger::ScLogType::File;
-  m_logFileStream.open(logFile, std::ofstream::out | std::ofstream::trunc);
+  m_logFileStream.open(logFile, std::ofstream::out | (append ? std::ofstream::app : std::ofstream::trunc));
 }
 
 void ScLogger::SetLogLevel(ScLogLevel const & logLevel)

--- a/sc-memory/sc-memory/tests/sc-memory/units/common/test_sc_debug.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/common/test_sc_debug.cpp
@@ -281,6 +281,32 @@ TEST_F(ScLoggerTest, FileLoggingWritesCorrectMessage)
   std::remove(testFile.c_str());
 }
 
+TEST_F(ScLoggerTest, AppendLogsToFile)
+{
+  std::string const testFile = "test_log.txt";
+
+  std::ofstream ofs(testFile);
+  ofs.close();
+
+  m_logger.SetLogFile(testFile);
+  m_logger.Info("This is the first log message.");
+
+  m_logger = utils::ScLogger(utils::ScLogger::ScLogType::File, testFile, utils::ScLogLevel::Level::Debug, true);
+  m_logger.Info("This is the second log message.");
+
+  std::ifstream ifs(testFile);
+  std::string line;
+
+  std::getline(ifs, line);
+  EXPECT_NE(line.find("This is the first log message."), std::string::npos);
+
+  std::getline(ifs, line);
+  EXPECT_NE(line.find("This is the second log message."), std::string::npos);
+
+  ifs.close();
+  std::remove(testFile.c_str());
+}
+
 TEST_F(ScLoggerTest, InvalidLogFilePath)
 {
   std::string const testFile = "/invalid/path/to/log.txt";


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/CONTRIBUTING.md)
* [x] Update changelog
* [x] Update documentation

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `append` flag to `ScLogger` to enable appending logs to existing files.
> 
>   - **Behavior**:
>     - Add `append` flag to `ScLogger` constructor and `SetLogFile` method in `sc_logger.hpp` and `sc_logger.cpp` to allow appending logs to existing files.
>   - **Documentation**:
>     - Update `changelog.md` to include the new `append` flag feature for `ScLogger`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for 311549b5cbab8dc60ed97b5026b89f88078e9549. You can [customize](https://app.ellipsis.dev/ostis-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->