### PR TITLE
[refactor][memory] Remove extra ScAddr::Hash method calls in error messages: use operator converting to string

### DIFF
--- a/sc-memory/sc-memory/src/sc_action.cpp
+++ b/sc-memory/sc-memory/src/sc_action.cpp
@@ -222,9 +222,9 @@ void ScAction::Finish(ScAddr const & actionStateAddr) noexcept(false)
     if (m_context->IsElement(m_resultAddr) && foundResultAddr != m_resultAddr)
       SC_THROW_EXCEPTION(
           utils::ExceptionInvalidState,
-          "Not able to set result `" << m_resultAddr.Hash() << "` for action " << GetActionPrettyString()
+          "Not able to set result `" << m_resultAddr << "` for action " << GetActionPrettyString()
                                      << GetActionClassPrettyString() << " because it already has result `"
-                                     << foundResultAddr.Hash() << "`.");
+                                     << foundResultAddr << "`.");
   }
   else
   {
@@ -296,7 +296,7 @@ std::string ScAction::GetActionClassPrettyString() const
   {
     actionClassName = m_context->GetElementSystemIdentifier(actionClassAddr);
     if (actionClassName.empty())
-      actionClassName = std::to_string(actionClassAddr.Hash());
+      actionClassName = actionClassAddr;
   }
 
   if (!actionClassName.empty())

--- a/sc-memory/sc-memory/src/sc_addr.cpp
+++ b/sc-memory/sc-memory/src/sc_addr.cpp
@@ -10,7 +10,7 @@ ScAddr const ScAddr::Empty;
 
 ScAddr::ScAddr()
 {
-  SC_ADDR_MAKE_EMPTY(m_realAddr);
+  Reset();
 }
 
 ScAddr::ScAddr(sc_addr const & addr)
@@ -20,8 +20,8 @@ ScAddr::ScAddr(sc_addr const & addr)
 
 ScAddr::ScAddr(ScAddr::HashType const & hash)
 {
-  m_realAddr.offset = hash & 0xffff;
-  m_realAddr.seg = (hash >> 16) & 0xffff;
+  m_realAddr.offset = SC_ADDR_LOCAL_OFFSET_FROM_INT(hash);
+  m_realAddr.seg = SC_ADDR_LOCAL_SEG_FROM_INT(hash);
 }
 
 bool ScAddr::IsValid() const
@@ -36,7 +36,7 @@ void ScAddr::Reset()
 
 ScAddr::HashType ScAddr::Hash() const
 {
-  return ((m_realAddr.seg << 16) | m_realAddr.offset);
+  return SC_ADDR_LOCAL_TO_INT(m_realAddr);
 }
 
 bool ScAddr::operator==(ScAddr const & other) const
@@ -61,7 +61,7 @@ ScRealAddr const & ScAddr::GetRealAddr() const
 
 ScAddr::operator std::string() const
 {
-  return "`" + std::to_string(this->Hash()) + "`";
+  return std::to_string(this->Hash());
 }
 
 std::ostream & operator<<(std::ostream & os, ScAddr const & addr)
@@ -88,5 +88,5 @@ bool ScAddrLessFunc::operator()(ScAddr const & a, ScAddr const & b) const
 
 ScAddr::HashType ScAddrHashFunc::operator()(ScAddr const & addr) const
 {
-  return SC_ADDR_LOCAL_TO_INT(*addr);
+  return addr.Hash();
 }

--- a/sc-memory/sc-memory/src/sc_agent_context.cpp
+++ b/sc-memory/sc-memory/src/sc_agent_context.cpp
@@ -95,7 +95,7 @@ ScAction ScAgentContext::GenerateAction(ScAddr const & actionClassAddr) noexcept
   if (!IsElement(actionClassAddr))
     SC_THROW_EXCEPTION(
         utils::ExceptionInvalidParams,
-        "Not able to generate sc-action with action class `" << actionClassAddr.Hash()
+        "Not able to generate sc-action with action class `" << actionClassAddr
                                                              << "`, because action class is not valid.");
 
   ScAddr const & actionAddr = GenerateNode(ScType::ConstNode);
@@ -110,7 +110,7 @@ ScAction ScAgentContext::ConvertToAction(ScAddr const & actionAddr) noexcept(fal
     SC_THROW_EXCEPTION(
         utils::ExceptionInvalidParams,
         "Not able to convert sc-action sc-address `"
-            << actionAddr.Hash() << "` to object of `ScAction` class, because its sc-address is not valid.");
+            << actionAddr << "` to object of `ScAction` class, because its sc-address is not valid.");
 
   ScAction action{this, actionAddr};
   return action;
@@ -129,7 +129,7 @@ ScSet ScAgentContext::ConvertToSet(ScAddr const & setAddr) noexcept(false)
     SC_THROW_EXCEPTION(
         utils::ExceptionInvalidParams,
         "Not able to convert sc-set sc-address `"
-            << setAddr.Hash() << "` to object of `ScSet` class, because its sc-address is not valid.");
+            << setAddr << "` to object of `ScSet` class, because its sc-address is not valid.");
 
   ScSet set{this, setAddr};
   return set;
@@ -148,7 +148,7 @@ ScOrientedSet ScAgentContext::ConvertToOrientedSet(ScAddr const & setAddr) noexc
     SC_THROW_EXCEPTION(
         utils::ExceptionInvalidParams,
         "Not able to convert sc-oriented-set sc-address `"
-            << setAddr.Hash() << "` to object of `ScOrientedSet` class, because its sc-address is not valid.");
+            << setAddr << "` to object of `ScOrientedSet` class, because its sc-address is not valid.");
 
   ScOrientedSet set{this, setAddr};
   return set;
@@ -167,7 +167,7 @@ ScStructure ScAgentContext::ConvertToStructure(ScAddr const & structureAddr) noe
     SC_THROW_EXCEPTION(
         utils::ExceptionInvalidParams,
         "Not able to convert sc-structure sc-address `"
-            << structureAddr.Hash() << "` to object of `ScStructure` class, because its sc-address is not valid.");
+            << structureAddr << "` to object of `ScStructure` class, because its sc-address is not valid.");
 
   ScStructure structure{this, structureAddr};
   return structure;

--- a/sc-memory/sc-memory/src/sc_template.cpp
+++ b/sc-memory/sc-memory/src/sc_template.cpp
@@ -87,7 +87,7 @@ void ScTemplateItem::SetAddr(ScAddr const & addr, sc_char const * replName)
   if (replName)
     m_name = replName;
   else if (m_name.empty())
-    m_name = std::to_string(addr.Hash());
+    m_name = addr;
 }
 
 void ScTemplateItem::SetType(ScType const & type, sc_char const * replName)
@@ -169,7 +169,7 @@ ScTemplateParams & ScTemplateParams::Add(std::string const & varIdtf, ScAddr con
 
 ScTemplateParams & ScTemplateParams::Add(ScAddr const & varAddr, ScAddr const & value) noexcept(false)
 {
-  std::string const & varAddrHashStr = std::to_string(varAddr.Hash());
+  std::string const & varAddrHashStr = varAddr;
   if (m_templateItemsToParams.find(varAddrHashStr) == m_templateItemsToParams.cend())
   {
     m_templateItemsToParams[varAddrHashStr] = value;
@@ -194,7 +194,7 @@ bool ScTemplateParams::Get(std::string const & varIdtf, ScAddr & outAddr) const 
 
 bool ScTemplateParams::Get(ScAddr const & varAddr, ScAddr & outAddr) const noexcept
 {
-  std::string const & varAddrHashStr = std::to_string(varAddr.Hash());
+  std::string const & varAddrHashStr = varAddr;
   auto const it = m_templateItemsToParams.find(varAddrHashStr);
   if (it != m_templateItemsToParams.cend())
   {
@@ -322,7 +322,7 @@ bool ScTemplate::HasReplacement(std::string const & repl) const
 
 bool ScTemplate::HasReplacement(ScAddr const & replAddr) const
 {
-  return m_templateItemsNamesToReplacementItemsPositions.find(std::to_string(replAddr.Hash()))
+  return m_templateItemsNamesToReplacementItemsPositions.find(replAddr)
          != m_templateItemsNamesToReplacementItemsPositions.cend();
 }
 
@@ -526,7 +526,7 @@ ScAddr ScTemplateResultItem::operator[](ScAddr const & varAddr) const noexcept(f
   if (addr.IsValid())
     return addr;
 
-  SC_THROW_EXCEPTION(utils::ExceptionInvalidParams, "Var=" << varAddr.Hash() << " not found in replacements");
+  SC_THROW_EXCEPTION(utils::ExceptionInvalidParams, "Variable `" << varAddr << "` not found in replacements");
 }
 
 bool ScTemplateResultItem::Get(std::string const & name, ScAddr & outAddr) const noexcept
@@ -548,7 +548,7 @@ ScAddr ScTemplateResultItem::operator[](std::string const & name) const noexcept
   if (addr.IsValid())
     return addr;
 
-  SC_THROW_EXCEPTION(utils::ExceptionInvalidParams, "Alias=`" << name << "` not found in replacements");
+  SC_THROW_EXCEPTION(utils::ExceptionInvalidParams, "Alias `" << name << "` not found in replacements");
 }
 
 bool ScTemplateResultItem::Get(size_t index, ScAddr & outAddr) const noexcept
@@ -612,7 +612,7 @@ ScAddr ScTemplateResultItem::GetAddrByName(std::string const & name) const
   ScAddr const & addr = m_context->SearchElementBySystemIdentifier(name);
   if (addr.IsValid())
   {
-    it = m_templateItemsNamesToReplacementItemPositions.find(std::to_string(addr.Hash()));
+    it = m_templateItemsNamesToReplacementItemPositions.find(addr);
     if (it != m_templateItemsNamesToReplacementItemPositions.cend())
       return m_replacementConstruction[it->second];
   }
@@ -625,7 +625,7 @@ ScAddr ScTemplateResultItem::GetAddrByVarAddr(ScAddr const & varAddr) const
   if (!varAddr.IsValid())
     return ScAddr::Empty;
 
-  auto it = m_templateItemsNamesToReplacementItemPositions.find(std::to_string(varAddr.Hash()));
+  auto it = m_templateItemsNamesToReplacementItemPositions.find(varAddr);
   if (it != m_templateItemsNamesToReplacementItemPositions.cend())
     return m_replacementConstruction[it->second];
 

--- a/sc-memory/sc-memory/src/sc_template_build.cpp
+++ b/sc-memory/sc-memory/src/sc_template_build.cpp
@@ -100,12 +100,12 @@ protected:
       ScAddr const & addr = m_context.SearchElementBySystemIdentifier(item.first);
       if (m_context.IsElement(addr))
       {
-        ObjectInfo obj = CollectObjectInfo(item.second, std::to_string(addr.Hash()));
+        ObjectInfo obj = CollectObjectInfo(item.second, addr);
         m_elements.insert({addr.Hash(), obj});
       }
       else
       {
-        ObjectInfo obj = CollectObjectInfo(item.second, std::to_string(item.second.Hash()));
+        ObjectInfo obj = CollectObjectInfo(item.second, item.second);
         std::stringstream ss(item.first);
         sc_addr_hash hash;
         ss >> hash;
@@ -187,7 +187,7 @@ private:
   {
     ScType const objType = m_context.GetElementType(objAddr);
     if (objIdtf.empty())
-      objIdtf = std::to_string(objAddr.Hash());
+      objIdtf = objAddr;
 
     return {objAddr, objType, objIdtf};
   }

--- a/sc-memory/sc-memory/src/sc_template_gen.cpp
+++ b/sc-memory/sc-memory/src/sc_template_gen.cpp
@@ -195,14 +195,11 @@ private:
     if (sourceItem.IsAddr() && sourceItem.m_addrValue != foundSourceAddr)
       SC_THROW_EXCEPTION(
           utils::ExceptionInvalidParams,
-          "Specified sc-connector `" << std::to_string(connectorAddr.Hash())
-                                     << "` as parameter for the second item in sc-template "
+          "Specified sc-connector `" << connectorAddr << "` as parameter for the second item in sc-template "
                                      << (connectorItem.HasName() ? (connectorItem.GetPrettyName() + " ") : "")
-                                     << "is not incident to specified source sc-element `"
-                                     << std::to_string(sourceItem.m_addrValue.Hash())
+                                     << "is not incident to specified source sc-element `" << sourceItem.m_addrValue
                                      << "` as fixed first item in sc-template " << sourceItem.GetPrettyName()
-                                     << ". This sc-connector is incident to sc-element `"
-                                     << std::to_string(foundSourceAddr.Hash()) << "`.");
+                                     << ". This sc-connector is incident to sc-element `" << foundSourceAddr << "`.");
 
     if (sourceItem.HasName())
     {
@@ -210,25 +207,22 @@ private:
       if (itemIt != m_params.m_templateItemsToParams.cend() && itemIt->second != foundSourceAddr)
         SC_THROW_EXCEPTION(
             utils::ExceptionInvalidParams,
-            "Specified sc-connector `"
-                << std::to_string(connectorAddr.Hash()) << "` as parameter for the second item in sc-template "
-                << (connectorItem.HasName() ? (connectorItem.GetPrettyName() + " ") : "")
-                << "is not incident to specified source sc-element `" << std::to_string(itemIt->second.Hash())
-                << "` as parameter for the first item in sc-template " << sourceItem.GetPrettyName()
-                << ". This sc-connector is incident to sc-element `" << std::to_string(foundSourceAddr.Hash()) << "`.");
+            "Specified sc-connector `" << connectorAddr << "` as parameter for the second item in sc-template "
+                                       << (connectorItem.HasName() ? (connectorItem.GetPrettyName() + " ") : "")
+                                       << "is not incident to specified source sc-element `" << itemIt->second
+                                       << "` as parameter for the first item in sc-template "
+                                       << sourceItem.GetPrettyName()
+                                       << ". This sc-connector is incident to sc-element `" << foundSourceAddr << "`.");
     }
 
     if (targetItem.IsAddr() && targetItem.m_addrValue != foundTargetAddr)
       SC_THROW_EXCEPTION(
           utils::ExceptionInvalidParams,
-          "Specified sc-connector `" << std::to_string(connectorAddr.Hash())
-                                     << "` as parameter for the second item in sc-template "
+          "Specified sc-connector `" << connectorAddr << "` as parameter for the second item in sc-template "
                                      << (connectorItem.HasName() ? (connectorItem.GetPrettyName() + " ") : "")
-                                     << "is not incident to specified target sc-element `"
-                                     << std::to_string(targetItem.m_addrValue.Hash())
+                                     << "is not incident to specified target sc-element `" << targetItem.m_addrValue
                                      << "` as fixed third item in sc-template " << targetItem.GetPrettyName()
-                                     << ". This sc-connector is incident to sc-element `"
-                                     << std::to_string(foundTargetAddr.Hash()) << "`.");
+                                     << ". This sc-connector is incident to sc-element `" << foundTargetAddr << "`.");
 
     if (targetItem.HasName())
     {
@@ -236,14 +230,11 @@ private:
       if (itemIt != m_params.m_templateItemsToParams.cend() && itemIt->second != foundTargetAddr)
         SC_THROW_EXCEPTION(
             utils::ExceptionInvalidParams,
-            "Specified sc-connector `" << std::to_string(connectorAddr.Hash())
-                                       << "` as parameter for the second item in sc-template "
+            "Specified sc-connector `" << connectorAddr << "` as parameter for the second item in sc-template "
                                        << (connectorItem.HasName() ? (connectorItem.GetPrettyName() + " ") : "")
-                                       << "is not incident to specified target sc-element `"
-                                       << std::to_string(itemIt->second.Hash())
+                                       << "is not incident to specified target sc-element `" << itemIt->second
                                        << "` as fixed third item in sc-template " << targetItem.GetPrettyName()
-                                       << ". This sc-connector is incident to sc-element `"
-                                       << std::to_string(foundTargetAddr.Hash()) << "`.");
+                                       << ". This sc-connector is incident to sc-element `" << foundTargetAddr << "`.");
     }
   };
 
@@ -267,7 +258,7 @@ private:
                 << templateParamReplacementName
                 << "` given in parameters, for which you want to perform substitution from these parameters.");
 
-      addrHashStr = std::to_string(varAddr.Hash());
+      addrHashStr = varAddr;
       replacementIt = m_replacements.find(addrHashStr);
       if (replacementIt == m_replacements.cend())
         SC_THROW_EXCEPTION(
@@ -293,9 +284,8 @@ private:
             utils::ExceptionInvalidParams,
             "Template item " << (templateItem.HasName() ? (templateItem.GetPrettyName() + " ") : "") << "has type `"
                              << std::string(templateItemType)
-                             << "`. This item can't be replaced by template parameter `"
-                             << std::to_string(templateParamAddr.Hash()) << "`, because it has type `"
-                             << std::string(templateParamType)
+                             << "`. This item can't be replaced by template parameter `" << templateParamAddr
+                             << "`, because it has type `" << std::string(templateParamType)
                              << "` and up-constant template item type can't be extended to template parameter type.");
     };
 


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/CONTRIBUTING.md)
* [x] Update changelog
* [x] Update documentation

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor to replace `ScAddr::Hash()` calls with `operator std::string()` for improved string conversion and error messaging consistency.
> 
>   - **Behavior**:
>     - Replaces `ScAddr::Hash()` calls with `operator std::string()` in error messages and string conversions in `sc_action.cpp`, `sc_agent_context.cpp`, and `sc_template.cpp`.
>     - Ensures consistent string representation of `ScAddr` objects across the codebase.
>   - **Functions**:
>     - Updates `ScAddr::operator std::string()` to directly convert `ScAddr` to string without backticks.
>     - Modifies `ScAddr::Hash()` to use `SC_ADDR_LOCAL_TO_INT()` for hash calculation.
>   - **Misc**:
>     - Refactors `ScAddr` constructor to use `SC_ADDR_LOCAL_OFFSET_FROM_INT()` and `SC_ADDR_LOCAL_SEG_FROM_INT()` for setting `m_realAddr`.
>     - Adjusts exception messages in `ScTemplateGenerator` to use updated `ScAddr` string conversion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for e45711c1a18b07762b842ef8a2aa3195d1ac7d39. You can [customize](https://app.ellipsis.dev/ostis-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->