### PR TITLE
[memory][set] GetElements methods for ScSet class

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `GetElements` method for `ScSet` class to get all elements of set with their roles
+- `GetElements` method for `ScSet` class to get all elements of set
 - ScOrientedSet class to work with sets of sc-elements ordered by nrel_basic_sequence relation
 - Methods for `ScSet` class: `Next`, `Reset`, `ForEach`
 - Operator for converting ScAddr to string
@@ -20,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed 
 
-- Context template argument initialization in ScAgent class 
+- Constructor call for context template argument class provided in ScAgent class 
 
 ## [0.10.4] - 03.06.2025
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `GetElements` method for `ScSet` class to get all elements of set with their roles
+- `GetElementsByRoles` method for `ScSet` class to get all elements of set by their roles
 - `GetElements` method for `ScSet` class to get all elements of set
 - ScOrientedSet class to work with sets of sc-elements ordered by nrel_basic_sequence relation
 - Methods for `ScSet` class: `Next`, `Reset`, `ForEach`

--- a/sc-memory/sc-memory/include/sc-memory/sc_oriented_set.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/sc_oriented_set.hpp
@@ -74,7 +74,7 @@ public:
    * @param roles Set to be filled with role addresses associated with the current element.
    * @return sc-address of the next element, or ScAddr::Empty if at the end.
    */
-  _SC_EXTERN ScAddr Next(ScAddrSet & roles) const override;
+  _SC_EXTERN ScAddr Next(ScAddrUnorderedSet & roles) const override;
 
   /*!
    * @brief Returns the next element in the oriented set.

--- a/sc-memory/sc-memory/include/sc-memory/sc_set.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/sc_set.hpp
@@ -106,7 +106,7 @@ public:
    * @param roles Set to be filled with roles associated with the element.
    * @return The sc-address of the next element, or ScAddr::Empty if no more elements.
    */
-  _SC_EXTERN virtual ScAddr Next(ScAddrSet & roles) const;
+  _SC_EXTERN virtual ScAddr Next(ScAddrUnorderedSet & roles) const;
 
   /*!
    * @brief Returns the next element in the set.
@@ -133,6 +133,39 @@ public:
    */
   template <typename Func>
   _SC_EXTERN void ForEach(Func func) const;
+
+  /*!
+   * @brief Retrieves elements from the set that are associated with the specified roles.
+   *
+   * Iterates over the elements in the set and, for each element whose role address is present
+   * in the provided `roles` set, adds an entry to the `elements` map. The map is populated with
+   * the role address as the key and the corresponding element address as the value.
+   *
+   * @param roles A set of role addresses to filter elements by. Only elements associated with these roles will be
+   * included in the result.
+   *
+   * @param elements An output map that will be populated with role addresses as keys and their corresponding element
+   * addresses as values. Only elements whose roles are found in the `roles` set are included.
+   *
+   * @return Returns `true` if all roles in the set are found among the elements; returns `false` if there are any roles
+   * in the input set that are not associated with any element in the set.
+   */
+  _SC_EXTERN bool GetElementsByRoles(ScAddrUnorderedSet const & roles, ScAddrToValueUnorderedMap<ScAddr> & elements)
+      const;
+
+  /*!
+   * @brief Retrieves all element addresses from the set.
+   *
+   * Clears the provided `elements` set and then populates it with the addresses of all elements contained
+   * in this set. After this method is called, `elements` will contain only the element addresses from this set.
+   *
+   * @param elements
+   *   An output set that will be cleared and then filled with the addresses of all elements in the set.
+   *
+   * @note
+   *   Any previous contents of `elements` will be removed.
+   */
+  _SC_EXTERN void GetElements(ScAddrUnorderedSet & elements) const;
 
 protected:
   /*!

--- a/sc-memory/sc-memory/include/sc-memory/sc_set.hpp
+++ b/sc-memory/sc-memory/include/sc-memory/sc_set.hpp
@@ -139,7 +139,8 @@ public:
    *
    * Iterates over the elements in the set and, for each element whose role address is present
    * in the provided `roles` set, adds an entry to the `elements` map. The map is populated with
-   * the role address as the key and the corresponding element address as the value.
+   * the role address as the key and the corresponding element address as the value. If multiple elements share the same
+   * role, only one will be stored per role.
    *
    * @param roles A set of role addresses to filter elements by. Only elements associated with these roles will be
    * included in the result.

--- a/sc-memory/sc-memory/src/sc_oriented_set.cpp
+++ b/sc-memory/sc-memory/src/sc_oriented_set.cpp
@@ -134,7 +134,7 @@ bool ScOrientedSet::Remove(ScAddr const & elementAddr, ScType const & arcType)
   return removed;
 }
 
-ScAddr ScOrientedSet::Next(ScAddrSet & roles) const
+ScAddr ScOrientedSet::Next(ScAddrUnorderedSet & roles) const
 {
   if (!m_currentArcAddr.IsValid())
     return ScAddr::Empty;
@@ -160,7 +160,7 @@ ScAddr ScOrientedSet::Next(ScAddrSet & roles) const
 
 ScAddr ScOrientedSet::Next() const
 {
-  ScAddrSet roles;
+  ScAddrUnorderedSet roles;
   return Next(roles);
 }
 

--- a/sc-memory/sc-memory/src/sc_set.cpp
+++ b/sc-memory/sc-memory/src/sc_set.cpp
@@ -93,7 +93,7 @@ size_t ScSet::GetPower() const
   return power;
 }
 
-ScAddr ScSet::Next(ScAddrSet & roles) const
+ScAddr ScSet::Next(ScAddrUnorderedSet & roles) const
 {
   if (!m_elementsIterator || !m_elementsIterator->IsValid())
     m_elementsIterator = m_context->CreateIterator3(*this, ScType::ConstPosArc, ScType::Unknown);
@@ -113,11 +113,37 @@ ScAddr ScSet::Next(ScAddrSet & roles) const
 
 ScAddr ScSet::Next() const
 {
-  ScAddrSet roles;
+  ScAddrUnorderedSet roles;
   return Next(roles);
 }
 
 void ScSet::Reset()
 {
   m_elementsIterator = nullptr;
+}
+
+bool ScSet::GetElementsByRoles(ScAddrUnorderedSet const & roles, ScAddrToValueUnorderedMap<ScAddr> & elements) const
+{
+  elements.clear();
+  ScAddrUnorderedSet notFoundRoles;
+  ForEach(
+      [&](ScAddr const &, ScAddr const & elementAddr, ScAddr const &, ScAddr const & roleAddr)
+      {
+        if (roles.count(roleAddr))
+          elements[roleAddr] = elementAddr;
+        else
+          notFoundRoles.insert(roleAddr);
+      });
+
+  return notFoundRoles.empty();
+}
+
+_SC_EXTERN void ScSet::GetElements(ScAddrUnorderedSet & elements) const
+{
+  elements.clear();
+  ForEach(
+      [&](ScAddr const &, ScAddr const & elementAddr, ScAddr const &, ScAddr const &)
+      {
+        elements.insert(elementAddr);
+      });
 }

--- a/sc-memory/sc-memory/src/sc_set.cpp
+++ b/sc-memory/sc-memory/src/sc_set.cpp
@@ -125,14 +125,15 @@ void ScSet::Reset()
 bool ScSet::GetElementsByRoles(ScAddrUnorderedSet const & roles, ScAddrToValueUnorderedMap<ScAddr> & elements) const
 {
   elements.clear();
-  ScAddrUnorderedSet notFoundRoles;
+  ScAddrUnorderedSet notFoundRoles{roles};
   ForEach(
       [&](ScAddr const &, ScAddr const & elementAddr, ScAddr const &, ScAddr const & roleAddr)
       {
         if (roles.count(roleAddr))
+        {
           elements[roleAddr] = elementAddr;
-        else
-          notFoundRoles.insert(roleAddr);
+          notFoundRoles.erase(roleAddr);
+        }
       });
 
   return notFoundRoles.empty();

--- a/sc-memory/sc-memory/tests/sc-memory/units/common/test_sc_oriented_set.cpp
+++ b/sc-memory/sc-memory/tests/sc-memory/units/common/test_sc_oriented_set.cpp
@@ -46,7 +46,7 @@ TEST_F(ScOrientedSetTest, AppendWithRole)
   EXPECT_TRUE(set.Append(element, role));
 
   set.Reset();
-  ScAddrSet roles;
+  ScAddrUnorderedSet roles;
   ScAddr Next = set.Next(roles);
   EXPECT_EQ(Next, element);
   EXPECT_EQ(roles.size(), 3u);


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/CONTRIBUTING.md)
* [x] Update changelog
* [x] Update documentation

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `GetElementsByRoles` and `GetElements` methods to `ScSet` and update `Next` method to use `ScAddrUnorderedSet`.
> 
>   - **Methods Added**:
>     - `GetElementsByRoles` in `ScSet` to retrieve elements by roles.
>     - `GetElements` in `ScSet` to retrieve all elements.
>   - **Method Updates**:
>     - `Next` method in `ScSet` and `ScOrientedSet` now uses `ScAddrUnorderedSet`.
>   - **Tests**:
>     - Added tests for `GetElementsByRoles` and `GetElements` in `test_sc_set.cpp`.
>     - Updated tests for `Next` method in `test_sc_set.cpp` and `test_sc_oriented_set.cpp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for 83c63bd40671b669af5b57115cb9360dcefa105f. You can [customize](https://app.ellipsis.dev/ostis-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->