### PR TITLE
[memory][template][build] Optimize grouping connectors by level in ScTemplateBuilder

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Optimize grouping connectors by level in `ScTemplateBuilder`
 - Rename method `HasElement` in `ScSet` class to `Has`
 
 ### Fixed 

--- a/sc-memory/sc-memory/src/sc_template_build.cpp
+++ b/sc-memory/sc-memory/src/sc_template_build.cpp
@@ -259,7 +259,7 @@ private:
       // and the current level is greater than the previously recorded maximum,
       // then update maxLevel.
       if (subLevel == nextLevel && currentLevel > maxLevel)
-        maxLevel = currentLevel;
+        maxLevel = std::max(maxLevel, subLevel + 1);
     }
     return currentLevel;
   }

--- a/sc-memory/sc-memory/src/sc_template_build.cpp
+++ b/sc-memory/sc-memory/src/sc_template_build.cpp
@@ -150,7 +150,7 @@ protected:
           m_connectorDependencyMap.insert({objInfo.GetHash(), targetAddr.Hash()});
       }
 
-      m_objectInfos.try_emplace(objInfo.GetHash(), std::move(objInfo));
+      m_objectInfos.insert_or_assign(objInfo.GetHash(), std::move(objInfo));
     }
 
     std::vector<HashSet> connectorsByDependencyLevel;


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/CONTRIBUTING.md)
* [x] Update changelog
* [x] Update documentation

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Optimize connector grouping by dependency level in `ScTemplateBuilder` for improved performance and clarity.
> 
>   - **Optimization**:
>     - Optimize grouping connectors by dependency level in `ScTemplateBuilder`.
>     - Use `LevelCache` for memoization in `GroupConnectorsByDependencyLevel()` and `GetConnectorDependencyLevel()`.
>   - **Class and Function Updates**:
>     - Rename `ObjectInfo` to `TemplateObjectInfo`.
>     - Rename `ConnectorDependenceMap` to `ConnectorDependencyMap`.
>     - Rename `ObjectToIdtfMap` to `ObjectHashToInfoMap`.
>     - Rename `ScAddrHashSet` to `HashSet`.
>     - Rename `SplitConnectorsByDependencePower()` to `GroupConnectorsByDependencyLevel()`.
>     - Rename `DefineConnectorDependencePower()` to `UpdateConnectorDependencyLevel()`.
>   - **Behavior Changes**:
>     - `operator()` in `ScTemplateBuilder` now groups connectors by dependency level before adding triples to the template.
>     - Improved handling of independent connectors and their dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fsc-machine&utm_source=github&utm_medium=referral)<sup> for c3b76088048a66aa391eebe7a05daeaaf0e0992a. You can [customize](https://app.ellipsis.dev/ostis-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->