### PR TITLE
[memory][extensions] Fix type for shutdown_func variable in _sc_ext_collect_extensions_from_directory function

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Install compilers (macOS)
         if: runner.os == 'macOS'
-        run: brew install cmake ninja ccache
+        run: brew install ninja ccache
 
       - name: Set Conan remote
         run: |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Type of shutdown_func variable in _sc_ext_collect_extensions_from_directory function
+
 ## [0.10.5] - 08.09.2025
 
 ### Added

--- a/sc-memory/sc-core/src/sc_memory_ext.c
+++ b/sc-memory/sc-core/src/sc_memory_ext.c
@@ -68,7 +68,7 @@ sc_result _sc_ext_collect_extensions_from_directory(sc_char const * extension_di
   GDir * extension_directory = null_ptr;
   sc_char const * file_name = null_ptr;
   fModuleInitializeFunc initialize_func = null_ptr;
-  fModuleInitializeFunc shutdown_func = null_ptr;
+  fModuleShutdownFunc shutdown_func = null_ptr;
 
   sc_message("Collect extensions from %s", extension_directory_path);
 


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/sc-machine/blob/main/docs/CONTRIBUTING.md)
* [x] Update changelog
* [ ] Update documentation

----
## Summary by Gitar

- **Memory extensions:**
    - Fixed `shutdown_func` type to `fModuleShutdownFunc` in `_sc_ext_collect_extensions_from_directory`.
- **CI workflow:**
    - Updated macOS release workflow to remove `cmake` from `brew` installation command in `release.yml`.
- **Documentation:**
    - Added entry for the fixed variable type in `changelog.md`.

<sub>This will update automatically on new commits.</sub>